### PR TITLE
feat: makes the use of "template" more flexible for Dropdown and FormDropdown

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -369,48 +369,47 @@ export function FormExamples() {
         options={[
           {
             value: {
+              firstValue: 'Title one',
+              secondvalue: 1,
+            },
+            label: {
               title: 'Title one',
               subtitle: 'subtitle one',
             },
-            label: (
-              <div>
-                <h5>Title one</h5>
-                <p>Subtitle one</p>
-              </div>
-            ),
           },
           {
             value: {
+              firstValue: 'Title two',
+              secondvalue: 2,
+            },
+            label: {
               title: 'Title two',
               subtitle: 'subtitle two',
             },
-            label: (
-              <div>
-                <h5>Title two</h5>
-                <p>Subtitle two</p>
-              </div>
-            ),
           },
           {
             value: {
+              firstValue: 'Title three',
+              secondvalue: 3,
+            },
+            label: {
               title: 'Title three',
               subtitle: 'subtitle three',
             },
-            label: (
-              <div>
-                <h5>Title three</h5>
-                <p>Subtitle three</p>
-              </div>
-            ),
           },
         ]}
         help="dropdown help"
         placeholder="Select one value"
         afterChange={() => console.log('afterChange dropdown')}
-        template={(label) => <div>{label}</div>}
+        template={(label) => (
+          <div>
+            <strong>{label.title ?? '-'}</strong>
+            <p className="m-0">{label.subtitle ?? '-'}</p>
+          </div>
+        )}
         itemClassName="border-bottom"
         childClassName="text-muted"
-        trackBy="title"
+        trackBy="secondvalue"
       />
 
       <FormGroupDropdown

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -401,12 +401,16 @@ export function FormExamples() {
         help="dropdown help"
         placeholder="Select one value"
         afterChange={() => console.log('afterChange dropdown')}
-        template={(label) => (
-          <div>
-            <strong>{label.title ?? '-'}</strong>
-            <p className="m-0">{label.subtitle ?? '-'}</p>
-          </div>
-        )}
+        template={(label, value) => {
+          return value ? (
+            <div>
+              <strong>{label.title ?? '-'}</strong>
+              <p className="m-0">{label.subtitle ?? '-'}</p>
+            </div>
+          ) : (
+            label
+          );
+        }}
         itemClassName="border-bottom"
         childClassName="text-muted"
         trackBy="secondvalue"

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -370,7 +370,7 @@ export function FormExamples() {
           {
             value: {
               firstValue: 'Title one',
-              secondvalue: 1,
+              secondValue: 1,
             },
             label: {
               title: 'Title one',
@@ -380,7 +380,7 @@ export function FormExamples() {
           {
             value: {
               firstValue: 'Title two',
-              secondvalue: 2,
+              secondValue: 2,
             },
             label: {
               title: 'Title two',
@@ -390,7 +390,7 @@ export function FormExamples() {
           {
             value: {
               firstValue: 'Title three',
-              secondvalue: 3,
+              secondValue: 3,
             },
             label: {
               title: 'Title three',
@@ -413,7 +413,7 @@ export function FormExamples() {
         }}
         itemClassName="border-bottom"
         childClassName="text-muted"
-        trackBy="secondvalue"
+        trackBy="secondValue"
       />
 
       <FormGroupDropdown

--- a/src/forms/FormDropdown.jsx
+++ b/src/forms/FormDropdown.jsx
@@ -81,9 +81,7 @@ export const FormDropdown = ({
     <div ref={dropdownRef}>
       <Dropdown
         isOpen={isOpen}
-        items={
-          includeEmptyItem ? [{ value: null, label: <div className="m-3"></div>, useTemplate: false }, ...items] : items
-        }
+        items={includeEmptyItem ? [{ value: null, label: <div className="m-3"></div> }, ...items] : items}
         onSelect={onSelectItem}
         template={template}
         itemClassName={itemClassName}

--- a/src/forms/FormDropdown.jsx
+++ b/src/forms/FormDropdown.jsx
@@ -57,7 +57,7 @@ export const FormDropdown = ({
   const toggleDropdown = useCallback(() => (isOpen ? close() : open()), [close, isOpen, open]);
 
   useEffect(() => {
-   /* The logic in this effect allows the user to close the dropdown menu when they click outside of the component. */
+    /* The logic in this effect allows the user to close the dropdown menu when they click outside of the component. */
     const pageClickEvent = (e) => {
       if (dropdownRef.current !== null && !dropdownRef.current.contains(e.target)) {
         if (isOpen) {
@@ -81,7 +81,9 @@ export const FormDropdown = ({
     <div ref={dropdownRef}>
       <Dropdown
         isOpen={isOpen}
-        items={includeEmptyItem ? [{ value: null, label: <div className="m-3"></div> }, ...items] : items}
+        items={
+          includeEmptyItem ? [{ value: null, label: <div className="m-3"></div>, useTemplate: false }, ...items] : items
+        }
         onSelect={onSelectItem}
         template={template}
         itemClassName={itemClassName}

--- a/src/forms/FormDropdown.jsx
+++ b/src/forms/FormDropdown.jsx
@@ -92,7 +92,7 @@ export const FormDropdown = ({
           className={formatClasses(['input-group justify-content-between form-control h-auto', childClassName])}
           onClick={toggleDropdown}
         >
-          {selectedItem ? template(selectedItem.label) : <div className="text-muted">{placeholder}</div>}
+          {selectedItem ? template(selectedItem.label, selectedItem.value) : <div className="text-muted">{placeholder}</div>}
           {toggleIcon(isOpen)}
         </div>
       </Dropdown>

--- a/src/mixed/Dropdown.jsx
+++ b/src/mixed/Dropdown.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { isNullLike } from 'js-var-type';
+
 import { safeClick } from '../utils/event-handlers';
 import { formatClasses } from '../utils/attributes';
 
@@ -30,14 +32,14 @@ export function Dropdown({
           // aria-labelledby="dropdownMenuButton"
           style={{ maxHeight: '200px', overflowY: 'auto' }}
         >
-          {items.map(({ label, value, isDisabled }, index) => (
+          {items.map(({ label, value, isDisabled, useTemplate }, index) => (
             <a
               key={index}
               href="#"
               className={formatClasses(['dropdown-item', isDisabled && 'disabled', itemClassName])}
               onClick={safeClick(onSelect, { value, index, label })}
             >
-              {template(label)}
+              {!isNullLike(useTemplate) && !useTemplate ? label : template(label)}
             </a>
           ))}
         </div>

--- a/src/mixed/Dropdown.jsx
+++ b/src/mixed/Dropdown.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { isNullLike } from 'js-var-type';
-
 import { safeClick } from '../utils/event-handlers';
 import { formatClasses } from '../utils/attributes';
 
@@ -32,14 +30,14 @@ export function Dropdown({
           // aria-labelledby="dropdownMenuButton"
           style={{ maxHeight: '200px', overflowY: 'auto' }}
         >
-          {items.map(({ label, value, isDisabled, useTemplate }, index) => (
+          {items.map(({ label, value, isDisabled }, index) => (
             <a
               key={index}
               href="#"
               className={formatClasses(['dropdown-item', isDisabled && 'disabled', itemClassName])}
               onClick={safeClick(onSelect, { value, index, label })}
             >
-              {!isNullLike(useTemplate) && !useTemplate ? label : template(label)}
+              {template(label, value, index)}
             </a>
           ))}
         </div>


### PR DESCRIPTION
Antes dessa correção, caso a props `includeEmptyItem` do componente `<FormDropdown />` fosse `true`, uma div vazia era incluída nas opções do dropdown para representar o valor "null". Caso o dev passasse um template para `<FormDropdown />`, a div vazia era formatada junto com os demais itens, o que causava esse tipo de problema: 

![image](https://user-images.githubusercontent.com/50001507/132024668-518b5a8b-0da6-4d8c-9c5e-c0018f959e15.png)

Código: 
Obs 1/2: `includeEmptyItem` por default já é `true`
``` js
       <FormGroupDropdown
                name="itemProgramacaoCampanha"
                label="Item de Programação"
                options={getItensProgramacaoFiltrados}
                placeholder="Selecione o item de programação..."
                childClassName="flex-nowrap"
                itemClassName="border-bottom no-active"
                menuClassName="p-0 w-100"
                template={(label) => (
                  <div className="my-2">
                    <strong>Tipo de Equipamento: </strong>
                    <span>{label.tipoEquipamento ?? '-'}</span>
                    <div>
                      <strong>Especificação Técnica: </strong>
                      <span>{label.especificacaoTecnica ?? '-'}</span>
                    </div>
                    <div>
                      <strong>Ponto de Investigação: </strong>
                      <span>{label.pontoInvestigacao ?? '-'}</span>
                    </div>
                  </div>
                )}
                toggleIcon={(isOpen) => (
                  <div className="d-flex align-items-center px-2">
                    <FontAwesomeIcon icon={isOpen ? faChevronUp : faChevronDown} />
                  </div>
                )}
              />
```

Obs 2/2: A alteração em `FormExamples` foi só pra tentar demonstrar melhor a correção