### PR TITLE
fix: fixes selected item in FormAutocomplete after useFormControl setValue and when values are objects

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -10,6 +10,7 @@ import {
   FormGroupTextarea,
   FormGroupAutocomplete,
   FormGroupDropdown,
+  useFormControl,
   // eslint-disable-next-line import/no-unresolved
 } from '../dist/main';
 
@@ -18,7 +19,7 @@ export function FormExamples() {
     <Form
       initialValues={{
         textField: 'abc',
-        autocompleteField1: '2345',
+        autocompleteField1: { _id: '2345', name: '2345 name' },
         autocompleteField4: 'unlisted item',
         selectField4: { e: 2, c: 'b' },
         switchField2: true,
@@ -150,10 +151,16 @@ export function FormExamples() {
         <div className="col">
           <FormGroupAutocomplete
             name="autocompleteField1"
-            label="Autocomplete"
-            options={['1234', '2345', '3456']}
+            label="Autocomplete Object Options"
+            options={[
+              { value: { _id: '1234', name: '1234 name' }, label: '1234 Label' },
+              { value: { _id: '2345', name: '2345 name' }, label: '2345 Label' },
+              { value: { _id: '3456', name: '3456 name' }, label: '3456 Label' },
+            ]}
             placeholder="Type some numbers"
+            trackBy="_id"
             help="Autocomplete help"
+            allowUnlistedValue
           />
         </div>
         <div className="col">
@@ -272,7 +279,7 @@ export function FormExamples() {
 
       <div className="row">
         <div className="col">
-          <FormGroupSwitch
+          <FormSwitchExample
             id="switchFieldId"
             name="switchField"
             label="Switch field"
@@ -441,3 +448,29 @@ export function FormExamples() {
     </Form>
   );
 }
+
+const FormSwitchExample = () => {
+  const autocompleteField1FormControl = useFormControl('autocompleteField1');
+
+  const afterChange = (value) => {
+    console.log('afterChange switch');
+
+    if (value) {
+      autocompleteField1FormControl.setValue({ _id: '3456', name: '3456 name' });
+    } else {
+      autocompleteField1FormControl.setValue(null);
+    }
+  };
+
+  return (
+    <FormGroupSwitch
+      id="switchFieldId"
+      name="switchField"
+      label="Switch field"
+      trueLabel="ON"
+      falseLabel="OFF"
+      help="Switch Autocomplete Object Options Value"
+      afterChange={afterChange}
+    />
+  );
+};

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -177,7 +177,6 @@ export function FormExamples() {
             onSearch={console.log}
             placeholder="Type some letters"
             openOnFocus={true}
-            required={() => true}
             afterChange={console.log.bind(console, 'afterChange autocomplete')}
           />
         </div>

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -6,31 +6,39 @@ import { Dropdown } from '../mixed/Dropdown';
 import { useOpenState } from '../utils/useOpenState';
 import { formatClasses } from '../utils/attributes';
 
-import { handleInputChange, normalizeOptions, booleanOrFunction } from './helpers/form-helpers';
+import {
+  booleanOrFunction,
+  valuesAreEqual,
+  getSelectedOption,
+  handleInputChange,
+  normalizeOptions,
+} from './helpers/form-helpers';
 import { useFormControl } from './helpers/useFormControl';
 import { FormGroup } from './FormGroup';
 
-function getSelectedItem(selectedItem, value, allowUnlistedValue) {
+function getSelectedItem(value, items, allowUnlistedValue, trackBy) {
+  const selectedItem = getSelectedOption(value, items, trackBy);
+
   if (isEmptyLike(selectedItem) && !isEmptyLike(value) && allowUnlistedValue) {
     return { value: value, label: value };
   }
 
   return selectedItem;
 }
-
 export function FormAutocomplete({
-  onSearch,
-  options,
-  required: _required,
-  id,
-  placeholder,
-  name,
-  openOnFocus,
-  template,
-  filter,
-  disabled: _disabled,
   afterChange,
   allowUnlistedValue,
+  disabled: _disabled,
+  filter,
+  id,
+  name,
+  onSearch,
+  openOnFocus,
+  options,
+  placeholder,
+  required: _required,
+  template,
+  trackBy,
 }) {
   const {
     getValue,
@@ -54,9 +62,8 @@ export function FormAutocomplete({
 
   const [searchValue, setSearchValue] = useState('');
   const items = normalizeOptions(options, getFormData(), searchValue);
-  const _selectedItem = items.find((item) => item.value === value);
 
-  const [selectedItem, setSelectedItem] = useState(getSelectedItem(_selectedItem, value, allowUnlistedValue));
+  const [selectedItem, setSelectedItem] = useState(getSelectedItem(value, items, allowUnlistedValue, trackBy));
   const { isOpen, open, close } = useOpenState();
   const [ignoreBlur, setIgnoreBlur] = useState(false);
   const [isFocused, setFocus] = useState(false);
@@ -169,6 +176,20 @@ export function FormAutocomplete({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    /* Handles case when a useFormControl.setValue is used. Without this logic,
+     * selectedItem would not be updaded. */
+    if (!valuesAreEqual(selectedItem?.value, value, trackBy)) {
+      const item = getSelectedItem(value, items, allowUnlistedValue, trackBy);
+
+      setSelectedItem(item);
+
+      if (item?.label) {
+        setSearchValue(item?.label);
+      }
+    }
+  }, [allowUnlistedValue, items, selectedItem?.value, trackBy, value]);
+
   return (
     <>
       <input
@@ -188,7 +209,11 @@ export function FormAutocomplete({
 
       {!isFocused && (
         <div
-          className={formatClasses(['form-control form-autocomplete-selected', controlFeedback])}
+          className={formatClasses([
+            'form-control form-autocomplete-selected',
+            controlFeedback,
+            disabled ? 'bg-light text-muted' : '',
+          ])}
           disabled={disabled}
           onClick={enableSearchInput}
         >
@@ -248,6 +273,7 @@ FormAutocomplete.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   template: PropTypes.func,
+  trackBy: PropTypes.string,
   type: PropTypes.string,
 };
 
@@ -277,5 +303,6 @@ FormGroupAutocomplete.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   template: PropTypes.func,
+  trackBy: PropTypes.string,
   type: PropTypes.string,
 };

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -113,7 +113,7 @@ export function FormAutocomplete({
       setValue('');
       setSelectedItem(null);
       updateSearchInputValidation();
-    } else if (selectedItem?.value !== searchValue && !isEmptyLike(searchValue) && allowUnlistedValue) {
+    } else if (selectedItem?.label !== searchValue && !isEmptyLike(searchValue) && allowUnlistedValue) {
       onSelectItem({ value: searchValue, label: searchValue });
     }
 

--- a/src/forms/helpers/form-helpers.js
+++ b/src/forms/helpers/form-helpers.js
@@ -162,3 +162,10 @@ export function decode(value, type) {
 
   return value;
 }
+
+export function valuesAreEqual(value1, value2, trackBy) {
+  const _value1 = value1 && isObject(value1) && trackBy ? getValueByPath(value1, trackBy) : value1;
+  const _value2 = value2 && isObject(value2) && trackBy ? getValueByPath(value2, trackBy) : value2;
+
+  return _value1 === _value2;
+}


### PR DESCRIPTION
Erro: quando o valor selecionado de um form autocomplete é um objeto, o valor no formData inicialmente era definido corretamente (isto é, um objeto) e logo em seguida era redefinido para um label.

https://user-images.githubusercontent.com/79877143/153650030-660df2c9-dd7e-4c1a-afd5-40982cb14476.mp4

Justificativa da correção: quando o "value" não é um objeto, o valor de value e label é igual, por isso o código funcionava. O valor de searchValue sempre corresponde ao label.
![image](https://user-images.githubusercontent.com/79877143/153650931-8597352e-82d7-459c-b238-705141b55092.png)

