### PR TITLE
fix: fixes initial load of formAutocomplete that allow unlisted values

### DIFF
--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -12,6 +12,7 @@ import {
   getSelectedOption,
   handleInputChange,
   normalizeOptions,
+  serializeValue,
 } from './helpers/form-helpers';
 import { useFormControl } from './helpers/useFormControl';
 import { FormGroup } from './FormGroup';
@@ -20,11 +21,12 @@ function getSelectedItem(value, items, allowUnlistedValue, trackBy) {
   const selectedItem = getSelectedOption(value, items, trackBy);
 
   if (isEmptyLike(selectedItem) && !isEmptyLike(value) && allowUnlistedValue) {
-    return { value: value, label: value };
+    return { value: value, label: serializeValue(value) };
   }
 
   return selectedItem;
 }
+
 export function FormAutocomplete({
   afterChange,
   allowUnlistedValue,

--- a/src/forms2/FormAutocomplete.jsx
+++ b/src/forms2/FormAutocomplete.jsx
@@ -6,31 +6,41 @@ import { Dropdown } from '../mixed/Dropdown';
 import { useOpenState } from '../utils/useOpenState';
 import { formatClasses } from '../utils/attributes';
 
-import { handleInputChange, normalizeOptions, booleanOrFunction } from './helpers/form-helpers';
+import {
+  booleanOrFunction,
+  getSelectedOption,
+  handleInputChange,
+  normalizeOptions,
+  serializeValue,
+  valuesAreEqual,
+} from './helpers/form-helpers';
 import { useFormControl2 } from './helpers/useFormControl';
 import { FormGroup2 } from './FormGroup';
 
-function getSelectedItem(selectedItem, value, allowUnlistedValue) {
+function getSelectedItem(value, items, allowUnlistedValue, trackBy) {
+  const selectedItem = getSelectedOption(value, items, trackBy);
+
   if (isEmptyLike(selectedItem) && !isEmptyLike(value) && allowUnlistedValue) {
-    return { value: value, label: value };
+    return { value: value, label: serializeValue(value) };
   }
 
   return selectedItem;
 }
 
 export function FormAutocomplete2({
-  onSearch,
-  options,
-  required: _required,
-  id,
-  placeholder,
-  name,
-  openOnFocus,
-  template,
-  filter,
-  disabled: _disabled,
   afterChange,
   allowUnlistedValue,
+  disabled: _disabled,
+  filter,
+  id,
+  name,
+  onSearch,
+  openOnFocus,
+  options,
+  placeholder,
+  required: _required,
+  template,
+  trackBy,
 }) {
   const {
     getValue,
@@ -54,9 +64,8 @@ export function FormAutocomplete2({
 
   const [searchValue, setSearchValue] = useState('');
   const items = normalizeOptions(options, getFormData(), searchValue);
-  const _selectedItem = items.find((item) => item.value === value);
 
-  const [selectedItem, setSelectedItem] = useState(getSelectedItem(_selectedItem, value, allowUnlistedValue));
+  const [selectedItem, setSelectedItem] = useState(getSelectedItem(value, items, allowUnlistedValue, trackBy));
   const { isOpen, open, close } = useOpenState();
   const [ignoreBlur, setIgnoreBlur] = useState(false);
   const [isFocused, setFocus] = useState(false);
@@ -112,7 +121,7 @@ export function FormAutocomplete2({
       setValue('');
       setSelectedItem(null);
       updateSearchInputValidation();
-    } else if (selectedItem?.value !== searchValue && !isEmptyLike(searchValue) && allowUnlistedValue) {
+    } else if (selectedItem?.label !== searchValue && !isEmptyLike(searchValue) && allowUnlistedValue) {
       onSelectItem({ value: searchValue, label: searchValue });
     }
 
@@ -168,6 +177,20 @@ export function FormAutocomplete2({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    /* Handles case when a useFormControl.setValue is used. Without this logic,
+     * selectedItem would not be updated. */
+    if (!valuesAreEqual(selectedItem?.value, value, trackBy)) {
+      const item = getSelectedItem(value, items, allowUnlistedValue, trackBy);
+
+      setSelectedItem(item);
+
+      if (item?.label) {
+        setSearchValue(item?.label);
+      }
+    }
+  }, [allowUnlistedValue, items, selectedItem?.value, trackBy, value]);
+
   return (
     <>
       <input
@@ -187,7 +210,11 @@ export function FormAutocomplete2({
 
       {!isFocused && (
         <div
-          className={formatClasses(['form-control form-autocomplete-selected', controlFeedback])}
+          className={formatClasses([
+            'form-control form-autocomplete-selected',
+            controlFeedback,
+            disabled ? 'bg-light text-muted' : '',
+          ])}
           disabled={disabled}
           onClick={enableSearchInput}
         >
@@ -247,6 +274,7 @@ FormAutocomplete2.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   template: PropTypes.func,
+  trackBy: PropTypes.string,
   type: PropTypes.string,
 };
 
@@ -276,5 +304,6 @@ FormGroupAutocomplete2.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   template: PropTypes.func,
+  trackBy: PropTypes.string,
   type: PropTypes.string,
 };


### PR DESCRIPTION
bug: erro ocorria quando:
1 - as options de um formAutocomplete ainda não haviam sido carregadas (dependiam de resposta de requisição ao servidor);
2 - a configuração allowUnlistedValue era escolhida
3 - o valor no formData respectivo ao componente do formAutocomplete vem prrenchido
4 - o valor (value) é um objeto (isto é, caso em que usamos a configuração trackBy)

![image](https://user-images.githubusercontent.com/79877143/155612386-c31ac6f8-e64a-43b1-9a19-449472e36065.png)

Explicação:
como ainda não tinha options, o valor selecionado encaixava nesse caso:
![image](https://user-images.githubusercontent.com/79877143/155612792-8b483912-60f6-4176-8426-257d3b1011b8.png)

Como o valor era um objeto, o `label` passava a ser um objeto e esse objeto era repassado diretamente para o jsx, causando o erro:
![image](https://user-images.githubusercontent.com/79877143/155613081-d67dc77a-f2c7-4c25-b7df-66b7ff2edc21.png)

