### PR TITLE
fix: fixes NaN values for FormInput

### DIFF
--- a/src/forms/helpers/form-helpers.js
+++ b/src/forms/helpers/form-helpers.js
@@ -153,7 +153,9 @@ export function encode(value, type) {
 
 export function decode(value, type) {
   if (type === 'number') {
-    return parseFloat(value);
+    const parsedValue = parseFloat(value);
+
+    return isNaN(parsedValue) ? getEmptyValue(type) : parsedValue;
   }
 
   if (type === 'boolean') {

--- a/src/forms2/helpers/form-helpers.js
+++ b/src/forms2/helpers/form-helpers.js
@@ -153,7 +153,9 @@ export function encode(value, type) {
 
 export function decode(value, type) {
   if (type === 'number') {
-    return parseFloat(value);
+    const parsedValue = parseFloat(value);
+
+    return isNaN(parsedValue) ? getEmptyValue(type) : parsedValue;
   }
 
   if (type === 'boolean') {


### PR DESCRIPTION
Enquanto testava edição de amostra, me deparei com esse caso.
![image](https://user-images.githubusercontent.com/79877143/161757912-5cd2caea-a861-4be6-8e30-5b9bd0d3318e.png)

Ao preencher o campo de input numérico e depois limpá-lo, o valor salvo no formData era NaN.