### PR TITLE
fix: fixes FormLabel when required prop is a function

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -161,6 +161,7 @@ export function FormExamples() {
             trackBy="_id"
             help="Autocomplete help"
             allowUnlistedValue
+            required={(formData) => formData.textField2}
           />
         </div>
         <div className="col">

--- a/src/forms/FormLabel.jsx
+++ b/src/forms/FormLabel.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isBoolean } from 'js-var-type';
+
+import { booleanOrFunction } from './helpers/form-helpers';
+import { useFormControl } from './helpers/useFormControl';
 
 export function FormLabel({ id, label, required: _required }) {
-  const required = isBoolean(_required) && _required;
+  const { getFormData } = useFormControl();
+  const required = booleanOrFunction(_required, getFormData());
 
   return (
     <label htmlFor={id}>

--- a/src/forms2/FormInputMask.jsx
+++ b/src/forms2/FormInputMask.jsx
@@ -82,6 +82,7 @@ export function FormGroupInputMask2(props) {
 }
 
 FormGroupInputMask2.propTypes = {
+  label: PropTypes.node.isRequired,
   mask: PropTypes.shape({
     format: PropTypes.func.isRequired,
     parse: PropTypes.func.isRequired,
@@ -92,7 +93,6 @@ FormGroupInputMask2.propTypes = {
     disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     help: PropTypes.node,
     id: PropTypes.string,
-    label: PropTypes.node.isRequired,
     max: PropTypes.string,
     maxLength: PropTypes.string,
     min: PropTypes.string,


### PR DESCRIPTION
When "required" was a function, the label would not work as expected. Regardless of the "required" result, the "label" was always "required false" because it was not a boolean.