### PR TITLE
fix: required form autocomplete using native form validation

### DIFF
--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -12,12 +12,14 @@ import {
   useFormControl2,
   useFormEffect,
   NumberMask,
+  FormGroupAutocomplete2,
 } from '../dist/main';
 
 export function Form2Examples() {
+  const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   return (
     <div className="pb-4">
-      Alternative Form implementation
+      <h4>Alternative Form implementation</h4>
       <Form2
         initialValues={{
           attrA: 'ABC',
@@ -51,8 +53,16 @@ export function Form2Examples() {
             }),
           };
         }}
-        customValidation={true}
+        customValidation={bootstrapFormValidation}
         validations={{
+          autocomplete2Field2: [
+            {
+              message: 'Must be filled if Autocomplete Object Options is empty',
+              validate(value, formData) {
+                return formData.autocomplete2Field1 || value;
+              },
+            },
+          ],
           attrB: [
             {
               message: 'Must be filled if AttrA is not empty',
@@ -63,6 +73,14 @@ export function Form2Examples() {
           ],
         }}
       >
+        <h5>Form configuration:</h5>
+        <FormGroupSwitch2
+          id="bootstrapForms2Validation"
+          name="bootstrapForm2Validation"
+          label="Use bootstrap form validation?"
+          afterChange={(value) => setBootstrapFormValidation(value)}
+        />
+        <hr />
         <div className="form-group">
           <label htmlFor="">Obj</label>
           <div className="form-row">
@@ -85,6 +103,44 @@ export function Form2Examples() {
           <label htmlFor="">Array of objects</label>
           <FormArrayOfObjects />
         </div>
+        <FormGroupAutocomplete2
+          name="autocomplete2Field1"
+          label="Autocomplete Object Options"
+          options={[
+            { value: { _id: '1234', name: '1234 name' }, label: '1234 Label' },
+            { value: { _id: '2345', name: '2345 name' }, label: '2345 Label' },
+            { value: { _id: '3456', name: '3456 name' }, label: '3456 Label' },
+          ]}
+          placeholder="Type some numbers"
+          trackBy="_id"
+          help="Autocomplete help"
+          allowUnlistedValue
+        />
+
+        <FormGroupAutocomplete2
+          name="autocomplete2Field2"
+          label="Autocomplete Field with Custom Validation"
+          options={['1', '2', '3']}
+          placeholder="Type some numbers"
+          allowUnlistedValue
+        />
+
+        <FormGroupAutocomplete2
+          name="autocomplete2Field3"
+          label="Autocomplete with item template"
+          options={Array.from({ length: 10 }).map((_, index) => ({
+            value: index + 1,
+            label: `${index + 1}${index + 2}${index + 3}${index + 4}`,
+          }))}
+          placeholder="Type some numbers"
+          template={(option) => (
+            <>
+              <strong>{option}</strong> - {option}
+            </>
+          )}
+          required={() => true}
+        />
+
         <FormGroupInput2 label="AttrA" name="attrA"></FormGroupInput2>
         <FormGroupInput2 label="AttrB" name="attrB"></FormGroupInput2>
         <FormGroupSelect2 label="AttrC" name="attrC" options={[1, 2, 3]}></FormGroupSelect2>

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Form,
   FormGroupInput,
@@ -15,6 +15,7 @@ import {
 } from '../dist/main';
 
 export function FormExamples() {
+  const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   return (
     <Form
       initialValues={{
@@ -51,7 +52,7 @@ export function FormExamples() {
         console.log('onCancel');
         resetForm();
       }}
-      customValidation={true}
+      customValidation={bootstrapFormValidation}
       validations={{
         numberField: [
           {
@@ -61,11 +62,11 @@ export function FormExamples() {
             },
           },
         ],
-        autocompleteField1: [
+        autocompleteField: [
           {
-            message: 'Must be filled if numberField is empty',
-            validate(value, formData) {
-              return formData.numberField || value;
+            message: 'Must be filled',
+            validate(value) {
+              return value;
             },
           },
         ],
@@ -111,6 +112,14 @@ export function FormExamples() {
         ],
       }}
     >
+      <h5>Form configuration:</h5>
+      <FormGroupSwitch
+        id="bootstrapFormValidation"
+        name="bootstrapFormValidation"
+        label="Use bootstrap form validation?"
+        afterChange={(value) => setBootstrapFormValidation(value)}
+      />
+      <hr />
       <div className="row">
         <div className="col">
           <FormGroupInput name="textField" label="Text field" disabled help="Text field help" />
@@ -146,6 +155,15 @@ export function FormExamples() {
             placeholder="Type some numbers"
             help="Disabled autocomplete"
             disabled
+          />
+        </div>
+        <div className="col">
+          <FormGroupAutocomplete
+            name="autocompleteField"
+            label="Autocomplete Field with Custom Validation"
+            options={['1', '2', '3']}
+            placeholder="Type some numbers"
+            allowUnlistedValue
           />
         </div>
         <div className="col">
@@ -195,7 +213,7 @@ export function FormExamples() {
                 <strong>{option}</strong> - {option}
               </>
             )}
-            required={() => false}
+            required={() => true}
           />
         </div>
         <div className="col">

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -226,14 +226,6 @@ export function FormAutocomplete({
         </div>
       )}
 
-      <input
-        type="text"
-        className={formatClasses(['form-control', 'd-none'])}
-        {...{ name, required, id }}
-        onChange={() => {}}
-        value={getValue()}
-        ref={registerRef}
-      />
 
       <Dropdown
         className="form-autocomplete-dropdown"
@@ -245,7 +237,17 @@ export function FormAutocomplete({
         onTouchStart={() => setIgnoreBlur(true)}
         onMouseEnter={() => setIgnoreBlur(true)}
         onMouseLeave={() => setIgnoreBlur(false)}
-      />
+      >
+        <input
+          type="text"
+          className={formatClasses(['form-control', 'position-absolute', 'fixed-bottom', 'opacity-0'])}
+          style={{ zIndex: '-9999' }}
+          {...{ name, required, id }}
+          onChange={() => {}}
+          value={getValue()}
+          ref={registerRef}
+        />
+      </Dropdown>
     </>
   );
 }

--- a/src/forms2/FormAutocomplete.jsx
+++ b/src/forms2/FormAutocomplete.jsx
@@ -224,15 +224,6 @@ export function FormAutocomplete2({
         </div>
       )}
 
-      <input
-        type="text"
-        className={formatClasses(['form-control', 'd-none'])}
-        {...{ name, required, id }}
-        onChange={() => {}}
-        value={getValue()}
-        ref={registerInputRef}
-      />
-
       <Dropdown
         className="form-autocomplete-dropdown"
         isOpen={isOpen()}
@@ -243,7 +234,17 @@ export function FormAutocomplete2({
         onTouchStart={() => setIgnoreBlur(true)}
         onMouseEnter={() => setIgnoreBlur(true)}
         onMouseLeave={() => setIgnoreBlur(false)}
-      />
+      >
+        <input
+          type="text"
+          className={formatClasses(['form-control', 'position-absolute', 'fixed-bottom', 'opacity-0'])}
+          style={{ zIndex: '-9999' }}
+          {...{ name, required, id }}
+          onChange={() => {}}
+          value={getValue()}
+          ref={registerInputRef}
+        />
+      </Dropdown>
     </>
   );
 }

--- a/src/forms2/helpers/useFormControl.jsx
+++ b/src/forms2/helpers/useFormControl.jsx
@@ -74,7 +74,7 @@ export function useFormControl2(name, type) {
     setFormData(newFormData) {
       return formHelper.updateFormData(newFormData);
     },
-    getFormSubmitedAttempted: () => formHelper.getFormSubmitedAttempted,
+    getFormSubmitedAttempted: () => formHelper.getSubmitedAttempted(),
     isValid: () => formHelper.getValidationMessage(name) === '',
     registerInputRef,
   };


### PR DESCRIPTION
Task: https://app.clickup.com/t/21fc86n

Existem dois tipos de validação nesse formulário: a validação nativa e a validação usando a estilização do bootstrap. A propriedade que define o estilo da validação é "customValidation". O problema ocorre apenas na validação nativa, devido ao "display: none" do input. 

P.S.: a correção foi realizada no Form e Form2. Esse PR não corrige o problema descrito em https://app.clickup.com/t/2j978jp .

Sem correção: 

https://user-images.githubusercontent.com/50001507/179245144-297ea871-fae1-4268-9dc3-c85c3716c916.mp4

Com correção:

https://user-images.githubusercontent.com/50001507/179245160-b8a8c1dc-ff31-436b-aa63-8f5a81484381.mp4

