### PR TITLE
fix: corrige prop onSelect do StatefulTabs

### DIFF
--- a/demo/TabsExamples.jsx
+++ b/demo/TabsExamples.jsx
@@ -69,7 +69,7 @@ export function TabsExamples() {
               { title: 'C', content: <Lorem header="Content C" /> },
             ]}
             vertical={true}
-            onSelect={console.log}
+            onSelect={(index) => console.log('Index selecionado ', index)}
           />
         </div>
         <div className="col">
@@ -82,6 +82,7 @@ export function TabsExamples() {
             ]}
             vertical={true}
             bordered={true}
+            onSelect={(index) => console.log('Index selecionado ', index)}
           />
         </div>
       </div>

--- a/src/tabs/StatefulTabs.jsx
+++ b/src/tabs/StatefulTabs.jsx
@@ -1,14 +1,26 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { isFunction } from 'js-var-type';
 
 import { useSelectedItem } from '../utils/useSelectedItem';
 
 import { Tabs } from './Tabs';
 
-export function StatefulTabs({ initialTab, tabs, ...props }) {
+export function StatefulTabs({ initialTab, tabs, onSelect, ...props }) {
   const { getSelected, select } = useSelectedItem(initialTab, tabs.length);
 
-  return <Tabs tabs={tabs} {...props} activeTab={getSelected()} onSelect={select} />;
+  const _onSelect = useCallback(
+    (index) => {
+      select(index);
+
+      if (isFunction(onSelect)) {
+        return onSelect(index);
+      }
+    },
+    [onSelect, select]
+  );
+
+  return <Tabs tabs={tabs} {...props} activeTab={getSelected()} onSelect={_onSelect} />;
 }
 
 StatefulTabs.propTypes = {


### PR DESCRIPTION
A prop "onSelect" era definida no PropTypes do StatefulTabs, mas ela nunca estava sendo utilizada.