### PR TITLE
feat: melhora useFormEffect

### DIFF
--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -175,6 +175,10 @@ export function Form2Examples() {
           <label htmlFor="">Observer</label>
           <FormObserver />
         </div>
+        <div className="form-group">
+          <label htmlFor="">Observer 2</label>
+          <FormObserver2 />
+        </div>
 
         <FormGroupInputMask2
           name="decimalMask"
@@ -393,4 +397,46 @@ function currencyMask(v) {
   maskedValue = maskedValue.replace(/(?=(\d{3})+(\D))\B/g, ',');
 
   return { maskedValue, rawValue };
+}
+
+function FormObserver2() {
+  const [toggleName, setToggleName] = useState(false);
+
+  return (
+    <div>
+      <div className=" mb-2">
+        <FormGroupSwitch2
+          id="formObserver2"
+          label="Element observed switch"
+          name="formObserver2"
+          trueLabel="observed-input-1"
+          falseLabel="observed-input-2"
+          afterChange={(v) => setToggleName(v)}
+        />
+      </div>
+      <FormObserved2ObservedComponent name={toggleName ? 'observed-input-1' : 'observed-input-2'} />
+    </div>
+  );
+}
+
+function FormObserved2ObservedComponent({ name }) {
+  const [value, setValue] = useState();
+
+  useFormEffect(
+    name,
+    (value) => {
+      setValue(value);
+    },
+    [name]
+  );
+
+  return (
+    <div>
+      <div className="row mb-2">
+        <div className="col-6">{`Input observed "${name}"`}</div>
+        <div className="col-6">{`Value "${value}"`}</div>
+      </div>
+      <FormGroupSwitch2 id={name} label="Observed input switch" name={name} />
+    </div>
+  );
 }

--- a/src/forms2/helpers/useFormEffect.jsx
+++ b/src/forms2/helpers/useFormEffect.jsx
@@ -2,7 +2,7 @@ import { useContext, useEffect } from 'react';
 
 import { FormContext } from './useFormHelper';
 
-export function useFormEffect(name, observerFn) {
+export function useFormEffect(name, observerFn, deps = []) {
   const formHelper = useContext(FormContext);
 
   useEffect(() => {
@@ -10,5 +10,5 @@ export function useFormEffect(name, observerFn) {
 
     return () => unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [...deps]);
 }


### PR DESCRIPTION
Possibilita passar dependencias para o effect que lida com os eventos

---

Este PR foi motivado pelo bug descrito no card "[corrigir exibição dos graficos de procedimentos na pre visualização do tipo de ensaio](https://app.clickup.com/t/864dxy583)". O bug acontecia porque não era possivel alterar um "formEffect" registrado sem parar de renderizar o componente em que ele foi registrado.

antes

https://user-images.githubusercontent.com/68669058/219108860-a21d7a67-4fd6-448d-bb1e-ba0db18ed822.mp4


depois

https://user-images.githubusercontent.com/68669058/219108886-8f0efdd1-c6ac-4cd1-992b-d83b347e6ed8.mp4



---

Videos gravados com o seguinte teste

```javascript
function Teste() {
  const [toggleName, setToggleName] = useState(true);

  return (
    <div className=" d-flex flex-column">
      <div className=" mb-2">
        <FormGroupSwitch2
          id="multiFormEffectDemo"
          label="Switch de name"
          name="multiFormEffectDemo"
          afterChange={() => setToggleName(!toggleName)}
        />
      </div>
      <ComponenteQueUsaFormEffectMasPosuiNameVariavel
        name={toggleName ? 'multiFormEffectDemo-1' : 'multiFormEffectDemo-2'}
      />
    </div>
  );
}

function ComponenteQueUsaFormEffectMasPosuiNameVariavel({ name }) {
  const [value, setValue] = useState();

  useFormEffect(
    name,
    (value) => {
      setValue(value);
    },
    [name]
  );

  return (
    <div className="">
      <div className="">{`value: ${value}`}</div>
      <FormGroupSwitch2 id={name} label="useFormEffect" name={name} />
    </div>
  );
}

```
