### PR TITLE
feat: Adiciona props para Dropdown e FormAutocomplete

### DIFF
--- a/demo/DropdownExamples.jsx
+++ b/demo/DropdownExamples.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 // eslint-disable-next-line import/no-unresolved
 import { Dropdown } from '../dist/main';
 
@@ -19,26 +19,73 @@ const items = [
 ];
 
 export function DropdownExamples() {
+  return (
+    <div className="row">
+      <SimpleDropdown />
+      <DropdownWithRef />
+    </div>
+  );
+}
+
+function SimpleDropdown() {
   const [isOpen, setIsOpen] = useState();
 
   return (
-    <div className="row">
-      <div className="col-6 mb-3">
-        <h1 className="h4">Simple dropdown</h1>
-        <button type="button" onClick={() => setIsOpen(true)}>
-          Simple dropdown
-        </button>
+    <div className="col-6 mb-3">
+      <h1 className="h4">Simple dropdown</h1>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Simple dropdown
+      </button>
 
-        <Dropdown
-          items={items}
-          isOpen={isOpen}
-          onSelect={(args) => {
-            // eslint-disable-next-line no-console
-            console.info('onSelect', args);
-            setIsOpen(false);
-          }}
-        />
-      </div>
+      <Dropdown
+        items={items}
+        isOpen={isOpen}
+        onSelect={(args) => {
+          // eslint-disable-next-line no-console
+          console.info('onSelect', args);
+          setIsOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+
+function DropdownWithRef() {
+  const [isOpen, setIsOpen] = useState();
+  const [filterString, setFilterString] = useState('');
+  const listContainerRef = useRef(null);
+
+  const filter = useCallback(
+    (item) => {
+      const itemValue = JSON.stringify(item.label).toLowerCase();
+      const searchValue = filterString.toLowerCase();
+
+      return itemValue.includes(searchValue);
+    },
+    [filterString]
+  );
+
+  useEffect(() => console.log('listContainerRef?.current: ', listContainerRef?.current), [filterString]);
+
+  return (
+    <div className="col-6 mb-3">
+      <h1 className="h4">Dropdown with ref</h1>
+      <input type="search" value={filterString} onChange={(e) => setFilterString(e.target.value)} />
+
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Dropdown with ref
+      </button>
+
+      <Dropdown
+        items={items.filter(filter)}
+        isOpen={isOpen}
+        onSelect={(args) => {
+          // eslint-disable-next-line no-console
+          console.info('onSelect', args);
+          setIsOpen(false);
+        }}
+        listContainerRef={listContainerRef}
+      />
     </div>
   );
 }

--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -142,6 +142,19 @@ export function Form2Examples() {
           required={() => true}
         />
 
+        <FormGroupAutocomplete2
+          name="autocomplete2Field4"
+          label="Autocomplete Field that logs when searched value is cleared"
+          options={['1', '2', '3']}
+          placeholder="Type some numbers"
+          afterChange={(newValue, oldValue) => {
+            console.log(oldValue, ' changed to  :>> ', newValue);
+          }}
+          onClearSearch={() => {
+            console.log('search has been cleared');
+          }}
+        />
+
         <FormGroupInput2 label="AttrA" name="attrA"></FormGroupInput2>
         <FormGroupInput2 label="AttrB" name="attrB"></FormGroupInput2>
         <FormGroupSelect2 label="AttrC" name="attrC" options={[1, 2, 3]}></FormGroupSelect2>

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -229,6 +229,20 @@ export function FormExamples() {
             }}
           />
         </div>
+        <div className="col">
+          <FormGroupAutocomplete
+            name="autocompleteField5"
+            label="Autocomplete that logs when searched value is cleared"
+            options={['1234', '2345', '3456']}
+            placeholder="Type some numbers"
+            afterChange={(newValue, oldValue) => {
+              console.log(oldValue, ' changed to  :>> ', newValue);
+            }}
+            onClearSearch={() => {
+              console.log('search has been cleared');
+            }}
+          />
+        </div>
       </div>
 
       <div className="row">

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -36,8 +36,10 @@ export function FormAutocomplete({
   disabled: _disabled,
   filter,
   id,
+  listContainerRef,
   name,
   onSearch,
+  onClearSearch,
   openOnFocus,
   options,
   placeholder,
@@ -91,8 +93,10 @@ export function FormAutocomplete({
     if (isEmptyLike(value) && !isFocused) {
       setSearchValue('');
       setSelectedItem(null);
+
+      return onClearSearch();
     }
-  }, [isFocused, value]);
+  }, [isFocused, value, onClearSearch]);
 
   const onSearchInputType = useCallback(
     (_, nextSearchValue) => {
@@ -243,6 +247,7 @@ export function FormAutocomplete({
         onTouchStart={() => setIgnoreBlur(true)}
         onMouseEnter={() => setIgnoreBlur(true)}
         onMouseLeave={() => setIgnoreBlur(false)}
+        listContainerRef={listContainerRef}
       >
         <input
           type="text"
@@ -261,6 +266,7 @@ export function FormAutocomplete({
 FormAutocomplete.defaultProps = {
   openOnFocus: false,
   onSearch: () => {},
+  onClearSearch: () => {},
   filter: (_searchValue) => (item) => {
     const itemValue = JSON.stringify(item.label).toLowerCase();
     const searchValue = _searchValue.toLowerCase();
@@ -276,8 +282,10 @@ FormAutocomplete.propTypes = {
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   filter: PropTypes.func,
   id: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   name: PropTypes.string.isRequired,
   onSearch: PropTypes.func,
+  onClearSearch: PropTypes.func,
   openOnFocus: PropTypes.bool,
   options: PropTypes.oneOfType([
     PropTypes.func,
@@ -306,8 +314,10 @@ FormGroupAutocomplete.propTypes = {
   help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.node.isRequired,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   name: PropTypes.string.isRequired,
   onSearch: PropTypes.func,
+  onClearSearch: PropTypes.func,
   openOnFocus: PropTypes.bool,
   options: PropTypes.oneOfType([
     PropTypes.func,

--- a/src/forms/FormDropdown.jsx
+++ b/src/forms/FormDropdown.jsx
@@ -17,6 +17,7 @@ export const FormDropdown = ({
   dropdownClassName,
   includeEmptyItem,
   itemClassName,
+  listContainerRef,
   menuClassName,
   name,
   options,
@@ -103,6 +104,7 @@ export const FormDropdown = ({
         itemClassName={itemClassName}
         className={dropdownClassName}
         menuClassName={menuClassName}
+        listContainerRef={listContainerRef}
       >
         <div
           className={formatClasses([
@@ -144,6 +146,7 @@ FormDropdown.propTypes = {
   dropdownClassName: PropTypes.string,
   includeEmptyItem: PropTypes.bool,
   itemClassName: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   menuClassName: PropTypes.string,
   name: PropTypes.string.isRequired,
   options: PropTypes.oneOfType([
@@ -172,6 +175,7 @@ FormGroupDropdown.propTypes = {
   help: PropTypes.node,
   includeEmptyItem: PropTypes.bool,
   itemClassName: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   menuClassName: PropTypes.string,
   name: PropTypes.string.isRequired,
   options: PropTypes.oneOfType([

--- a/src/forms2/FormAutocomplete.jsx
+++ b/src/forms2/FormAutocomplete.jsx
@@ -35,8 +35,10 @@ export function FormAutocomplete2({
   disabled: _disabled,
   filter,
   id,
+  listContainerRef,
   name,
   onSearch,
+  onClearSearch,
   openOnFocus,
   options,
   placeholder,
@@ -88,8 +90,10 @@ export function FormAutocomplete2({
     if (isEmptyLike(value) && !isFocused) {
       setSearchValue('');
       setSelectedItem(null);
+
+      return onClearSearch();
     }
-  }, [isFocused, value]);
+  }, [isFocused, value, onClearSearch]);
 
   const onSearchInputType = useCallback(
     (_, nextSearchValue) => {
@@ -236,6 +240,7 @@ export function FormAutocomplete2({
         onTouchStart={() => setIgnoreBlur(true)}
         onMouseEnter={() => setIgnoreBlur(true)}
         onMouseLeave={() => setIgnoreBlur(false)}
+        listContainerRef={listContainerRef}
       >
         <input
           type="text"
@@ -254,6 +259,7 @@ export function FormAutocomplete2({
 FormAutocomplete2.defaultProps = {
   openOnFocus: false,
   onSearch: () => {},
+  onClearSearch: () => {},
   filter: (_searchValue) => (item) => {
     const itemValue = JSON.stringify(item.label).toLowerCase();
     const searchValue = _searchValue.toLowerCase();
@@ -269,8 +275,10 @@ FormAutocomplete2.propTypes = {
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   filter: PropTypes.func,
   id: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   name: PropTypes.string.isRequired,
   onSearch: PropTypes.func,
+  onClearSearch: PropTypes.func,
   openOnFocus: PropTypes.bool,
   options: PropTypes.oneOfType([
     PropTypes.func,
@@ -299,8 +307,10 @@ FormGroupAutocomplete2.propTypes = {
   help: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.node.isRequired,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   name: PropTypes.string.isRequired,
   onSearch: PropTypes.func,
+  onClearSearch: PropTypes.func,
   openOnFocus: PropTypes.bool,
   options: PropTypes.oneOfType([
     PropTypes.func,

--- a/src/forms2/FormDropdown.jsx
+++ b/src/forms2/FormDropdown.jsx
@@ -17,6 +17,7 @@ export const FormDropdown2 = ({
   dropdownClassName,
   includeEmptyItem,
   itemClassName,
+  listContainerRef,
   menuClassName,
   name,
   options,
@@ -103,6 +104,7 @@ export const FormDropdown2 = ({
         itemClassName={itemClassName}
         className={dropdownClassName}
         menuClassName={menuClassName}
+        listContainerRef={listContainerRef}
       >
         <div
           className={formatClasses([
@@ -144,6 +146,7 @@ FormDropdown2.propTypes = {
   dropdownClassName: PropTypes.string,
   includeEmptyItem: PropTypes.bool,
   itemClassName: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   menuClassName: PropTypes.string,
   name: PropTypes.string.isRequired,
   options: PropTypes.oneOfType([
@@ -172,6 +175,7 @@ FormGroupDropdown2.propTypes = {
   help: PropTypes.node,
   includeEmptyItem: PropTypes.bool,
   itemClassName: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   menuClassName: PropTypes.string,
   name: PropTypes.string.isRequired,
   options: PropTypes.oneOfType([

--- a/src/mixed/Dropdown.jsx
+++ b/src/mixed/Dropdown.jsx
@@ -17,6 +17,7 @@ export function Dropdown({
   className,
   itemClassName,
   menuClassName,
+  listContainerRef,
 }) {
   return (
     <div
@@ -30,6 +31,7 @@ export function Dropdown({
           className={formatClasses(['dropdown-menu', menuClassName, isOpen && 'show'])}
           // aria-labelledby="dropdownMenuButton"
           style={{ maxHeight: '200px', overflowY: 'auto' }}
+          ref={listContainerRef}
         >
           {items.map(({ label, value, isDisabled }, index) => (
             <a
@@ -64,5 +66,6 @@ Dropdown.propTypes = {
   template: PropTypes.func,
   className: PropTypes.string,
   itemClassName: PropTypes.string,
+  listContainerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
   menuClassName: PropTypes.string,
 };


### PR DESCRIPTION
Este PR tem a intenção de implementar novas props para permitir a criação de um input autocomplete com scroll infinito.


## Sobre as alterações
### - listContainerRef
A intenção dessa prop é facilitar o acesso ao scroll dos itens de um Dropdown/FormAutocomplete. Sem ela, seria necessario usar um "useRef" com um "document.querySelector", e mais um "useState" para resetar a ref no autocomplete quando ele fica sem itens no Dropdown.

### - onClearSearch
A intenção dessa prop é possibilitar a execução de logica customizada após confirmar a limpeza dos filtros no autocomplete. Essa prop seria util em um caso especifico do https://github.com/geolaborapp/geolabor/pull/5650, em que ao digitar um filtro e clicar fora do autocomplete, o filtro visivel some, mas continua sendo aplicado na listagem de itens.