### PR TITLE
fix: corrige uso do onClearSearch

### DIFF
--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -94,7 +94,7 @@ export function FormAutocomplete({
       setSearchValue('');
       setSelectedItem(null);
 
-      return onClearSearch();
+      onClearSearch();
     }
   }, [isFocused, value, onClearSearch]);
 

--- a/src/forms2/FormAutocomplete.jsx
+++ b/src/forms2/FormAutocomplete.jsx
@@ -91,7 +91,7 @@ export function FormAutocomplete2({
       setSearchValue('');
       setSelectedItem(null);
 
-      return onClearSearch();
+      onClearSearch();
     }
   }, [isFocused, value, onClearSearch]);
 


### PR DESCRIPTION
No geolabor, em um teste no input autocomplete com scroll infinito apareceu essa mensagem de erro
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/5e7fe574-74e3-407f-8250-e9d2718a9b88)

Não consegui reproduzir o bug no bootstrap-utils, mas acredito que esse log aconteceu por causa do setState no onClearSearch.
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/56f4cfc9-5554-4bd0-943d-8b14fe8022ec)

Eu não tinha percebido que um `return` no `clearSearchValue` seria tratado como uma função de limpeza do useEffect.
 