### PR TITLE
fix: Corrige visualização dos valores em inputs no Form2 ao usar setValue

### DIFF
--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Form2,
   FormGroupCheckbox2,
@@ -281,6 +281,14 @@ export function Form2Examples() {
           template={(linha) => <p className="mb-0">{linha}</p>}
           disabled
         />
+
+        <FormGroupInput2
+          label="FormInput with value setted by useFormControl2().setValue()"
+          placeholder="Type something on the input below to update this value"
+          name="disabledFormInputForCustomSetValue"
+          disabled
+        />
+        <InputsWithCustomSetValue />
       </Form2>
     </div>
   );
@@ -378,6 +386,13 @@ function decimalMask(value) {
 }
 
 function dateMask(value) {
+  if (!value) {
+    return {
+      rawValue: null,
+      maskedValue: '',
+    };
+  }
+
   let maskedValue = String(value);
 
   maskedValue = maskedValue.replace(/\D/g, '');
@@ -392,7 +407,13 @@ function dateMask(value) {
 }
 
 function hourMask(v) {
-  let maskedValue = v;
+  if (!v) {
+    return {
+      rawValue: null,
+      maskedValue: '',
+    };
+  }
+  let maskedValue = String(v);
 
   maskedValue = maskedValue.replace(/\D/g, '');
   maskedValue = maskedValue.replace(/(\d{2})(\d)/, '$1:$2');
@@ -401,8 +422,14 @@ function hourMask(v) {
 }
 
 function currencyMask(v) {
+  if (!v) {
+    return {
+      rawValue: null,
+      maskedValue: '',
+    };
+  }
   const rawValue = parseFloat(v);
-  let maskedValue = v;
+  let maskedValue = String(v);
 
   maskedValue = maskedValue.replace(/\D/g, '');
   maskedValue = maskedValue.replace(/(\d)(\d{2})$/, '$1.$2');
@@ -450,5 +477,40 @@ function FormObserved2ObservedComponent({ name }) {
       </div>
       <FormGroupSwitch2 id={name} label="Observed input switch" name={name} />
     </div>
+  );
+}
+
+function InputsWithCustomSetValue() {
+  const formInputFormControl = useFormControl2('disabledFormInputForCustomSetValue');
+  const formInputMaskFormControl = useFormControl2('disabledFormInputMaskForCustomSetValue');
+
+  const mask = useMemo(
+    () => ({ parse: (value) => ({ rawValue: value, maskedValue: value }), format: (value) => value }),
+    []
+  );
+
+  return (
+    <>
+      <input
+        className="form-control mb-2"
+        placeholder="Type something to update the value of the form input above"
+        value={formInputFormControl.getValue()}
+        onChange={(e) => formInputFormControl.setValue(e.target.value)}
+      />
+      <div className="mb-2">
+        <FormGroupInputMask2
+          label="FormInputMask with value setted by useFormControl2().setValue()"
+          name="disabledFormInputMaskForCustomSetValue"
+          mask={mask}
+          inputAttrs={{ disabled: true, placeholder: 'Type something on the input below to update this value' }}
+        />
+        <input
+          className="form-control mb-2"
+          placeholder="Type something to update the value of the form input above"
+          value={formInputMaskFormControl.getValue()}
+          onChange={(e) => formInputMaskFormControl.setValue(e.target.value)}
+        />
+      </div>
+    </>
   );
 }

--- a/src/forms2/FormInputMask.jsx
+++ b/src/forms2/FormInputMask.jsx
@@ -27,6 +27,23 @@ export function FormInputMask2({ mask, name, inputAttrs }) {
     [formControl]
   );
 
+  const maskRefHandler = useCallback(
+    (input) => {
+      ref.current = input;
+      if (input) {
+        input.getMaskValue = (value) => {
+          const { maskedValue } = mask?.parse?.(value) ?? {};
+
+          return maskedValue;
+        };
+      }
+
+      formControl.registerInputRef(input);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mask] //formControl como dependencia causaria um loop infinito de render
+  );
+
   useEffect(() => {
     //formatação do valor inicial do input, deve ser executada apenas uma vez
     const valorInicialFormatado = mask?.format?.(valorInicial) ?? valorInicial;
@@ -44,7 +61,7 @@ export function FormInputMask2({ mask, name, inputAttrs }) {
   return (
     <>
       <input
-        ref={ref}
+        ref={maskRefHandler}
         className="form-control"
         name={`__mask.${name}`}
         defaultValue=""


### PR DESCRIPTION
#### Card [[react-bootstrap-utils] Corrigir exibição do valor de inputs ao alterar o valor usando o setValue no Form2](https://app.clickup.com/t/864dn2h7a)

### Descrição
Ao usar o setValue do hook useFormControl2, os valores do formulario eram alterados mas a visualização não. Este PR implementa uma correção para esse problema.

#### Com a correção

https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/417e0cc3-7571-4d92-b7ad-9d6f812ce308

#### Antes da correção

https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/dfc0ec4d-a58e-4f3f-b03c-82dd6da453b3


### Sobre a correção
A ideia foi usar o ""passo"" de notificação para atualizar o valor dos ""inputs no html"". 
No caso do FormInputMask2, como ele é um FormInput2 escondido com um input de mascara, a ideia foi registrar a mascara junto com o input normal, para quando atualizar o input ""escondido"" eu conseguir buscar o ""input mascara visivel""

### Para o testador
Favor testar bem os campos do formulario e as validações deles.