### PR TITLE
fix: Corrige titulo dinamico em Dialog

### DIFF
--- a/demo/DialogExamples.jsx
+++ b/demo/DialogExamples.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React from 'react';
+import React, { useState } from 'react';
 
 // eslint-disable-next-line import/no-unresolved
 import {
@@ -14,6 +14,7 @@ import {
 } from '../dist/main';
 
 export function DialogExamples() {
+  const [dialogComponentTitleType, setDialogComponentTitleType] = useState(false);
   const { showDialog, DialogPortal } = useDialog({
     title: 'useDialog',
     body: ({ foo, bar }) => (
@@ -48,6 +49,24 @@ export function DialogExamples() {
             <div>
               Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quibusdam sequi vero sapiente delectus error
               sunt, a eveniet nobis est ex magni nesciunt magnam. Eaque eius hic eligendi dolorum ut quas?
+            </div>
+          }
+          keyboard={false}
+        >
+          <a href="" className="btn btn-primary">
+            Simple Dialog
+          </a>
+        </Dialog>
+      </div>
+      <div className="col-6">
+        <h1 className="h4">Simple Dialog with component as title</h1>
+        <Dialog
+          title={<>Simple dialog {dialogComponentTitleType ? 'a' : 'b'}</>}
+          body={
+            <div>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quibusdam sequi vero sapiente delectus error
+              sunt, a eveniet nobis est ex magni nesciunt magnam. Eaque eius hic eligendi dolorum ut quas?
+              <button onClick={() => setDialogComponentTitleType((t) => !t)}>teste</button>
             </div>
           }
           keyboard={false}

--- a/demo/DialogExamples.jsx
+++ b/demo/DialogExamples.jsx
@@ -66,7 +66,7 @@ export function DialogExamples() {
             <div>
               Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quibusdam sequi vero sapiente delectus error
               sunt, a eveniet nobis est ex magni nesciunt magnam. Eaque eius hic eligendi dolorum ut quas?
-              <button onClick={() => setDialogComponentTitleType((t) => !t)}>teste</button>
+              <button onClick={() => setDialogComponentTitleType((t) => !t)}>click to toggle the title!</button>
             </div>
           }
           keyboard={false}

--- a/src/dialog/ModalPortal.jsx
+++ b/src/dialog/ModalPortal.jsx
@@ -8,14 +8,12 @@ export function ModalPortal({ children, title, isOpen }) {
   useEffect(() => {
     const modalPortalsElem = getModalPortalsElem();
 
-    if (!container) {
-      const containerElem = document.createElement('div');
+    const containerElem = document.createElement('div');
 
-      containerElem.dataset.title = title;
+    containerElem.dataset.title = title;
 
-      modalPortalsElem.appendChild(containerElem);
-      setContainer(containerElem);
-    }
+    modalPortalsElem.appendChild(containerElem);
+    setContainer(containerElem);
 
     return () => {
       if (!container) {
@@ -28,7 +26,9 @@ export function ModalPortal({ children, title, isOpen }) {
         modalPortalsElem.removeChild(container);
       }
     };
-  }, [container, title]);
+    //"container" causaria um loop infinito
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title]);
 
   //FIXME: prop to define if modal will be always included into DOM
   if (!container || !isOpen) {


### PR DESCRIPTION
#### card [Corrigir edição de atividade procedimento na edição de tipo de ensaio](https://app.clickup.com/t/86a0qkytm)

### Problema:
Quando um Dialog possui um titulo ""dinamico"", ao alterar o titulo, o modal some, mas o backdrop continua na tela.
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/412f6747-fd16-48d6-96b1-1e40e99804a1)

### Sobre o Dialog
O componente `Dialog` cria um `ModalPortal` com um `Modal`, o ""diferencial"" é que este modal não fica ""dentro"" do """"html/componente"""" onde o `Dialog` foi adicionado.
O `ModalPortal` usa a função [ReactDOM.createPortal](https://react.dev/reference/react-dom/createPortal#usage), que """teleporta""" o conteudo do `Modal` para uma `div` diretamente dentro do `body` do html

### Sobre a correção
Pelo que entendi, o erro era que ao atualizar o titulo, o `container` era removido do html, deixando o backdrop sem fechar o modal. 
Minha solução foi ajustar o effect para considerar apenas o `title` no array de dependencias, e sempre criar um novo container, porque esse `container` sempre será removido, no return do `useEffect`, quando o `title` atualizar ou o modal for fechado.

### Para o testador
Para reproduzir o bug, copie o DialogExamples deste PR, mude para a master, cole e rode o `npm start`
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/4758f16a-370a-486e-bd99-df6524f4d4c3)
