### PR TITLE
fix(form2): corrige atualização do setValue do formControl

### DIFF
--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -14,7 +14,7 @@ import {
   FormGroupAutocomplete2,
   FormGroupDropdown2,
   FormGroupRadio2,
-} from '../src/forms2';
+} from '../dist/main';
 
 export function Form2Examples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);

--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -655,7 +655,7 @@ function FormDropdownSetValueTeste1({}) {
       <div className="col">
         <FormGroupDropdown2
           label="Dropdown 1"
-          name="dropdown2"
+          name="dropdown1"
           afterChange={afterChange}
           options={[
             {

--- a/demo/Form2Examples.jsx
+++ b/demo/Form2Examples.jsx
@@ -14,10 +14,16 @@ import {
   FormGroupAutocomplete2,
   FormGroupDropdown2,
   FormGroupRadio2,
-} from '../dist/main';
+} from '../src/forms2';
 
 export function Form2Examples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
+  const [transform, setTransform] = useState(null);
+
+  const transform2 = useCallback((formData) => {
+    console.log('transform2', formData);
+  }, []);
+
   return (
     <div className="pb-4">
       <h4>Alternative Form implementation</h4>
@@ -32,28 +38,32 @@ export function Form2Examples() {
         }}
         onSubmit={(data) => console.log('onSubmit', data)}
         onChange={(data) => console.log('onChange', data)}
-        transform={(formData) => {
-          console.log('transform', formData);
+        transform={
+          transform === 2
+            ? transform2
+            : (formData) => {
+                console.log('transform', formData);
 
-          return {
-            __v: formData.__v ? formData.__v + 1 : 1,
-            attrB: `${formData.attrB || ''}A`,
-            Obj: {
-              y: `${formData.Obj.y || ''}X`,
-              w: {
-                z: formData.__v ? formData.__v * 2 : 1,
-              },
-              t: formData.__v % 2 ? null : undefined,
-              u: new Date(),
-            },
-            arr: formData.arr.map((v) => parseFloat(v) + 1),
-            arrObj: formData.arrObj.map((v) => {
-              v.o = parseFloat(v.o) ** 2;
+                return {
+                  __v: formData.__v ? formData.__v + 1 : 1,
+                  attrB: `${formData.attrB || ''}A`,
+                  Obj: {
+                    y: `${formData.Obj.y || ''}X`,
+                    w: {
+                      z: formData.__v ? formData.__v * 2 : 1,
+                    },
+                    t: formData.__v % 2 ? null : undefined,
+                    u: new Date(),
+                  },
+                  arr: formData.arr.map((v) => parseFloat(v) + 1),
+                  arrObj: formData.arrObj.map((v) => {
+                    v.o = parseFloat(v.o) ** 2;
 
-              return v;
-            }),
-          };
-        }}
+                    return v;
+                  }),
+                };
+              }
+        }
         customValidation={bootstrapFormValidation}
         validations={{
           autocomplete2Field2: [
@@ -283,6 +293,15 @@ export function Form2Examples() {
         />
 
         <h4>SetValue Test</h4>
+
+        <button
+          className="btn btn-info"
+          type="button"
+          onClick={() => (transform === 2 ? setTransform(null) : setTransform(2))}
+        >
+          Toggle transform
+        </button>
+
         <h5>FormInput</h5>
         <div className="row mb-2">
           <FormInputSetValueTeste1 />

--- a/src/forms2/FormInputMask.jsx
+++ b/src/forms2/FormInputMask.jsx
@@ -43,10 +43,8 @@ export function FormInputMask2({ mask, name, inputAttrs }) {
   );
 
   useEffect(() => {
-    //formatação do valor inicial do input, deve ser executada apenas uma vez
     setFormattedValue(valorInicial);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [setFormattedValue, valorInicial]);
 
   return (
     <>

--- a/src/forms2/helpers/useFormControl.jsx
+++ b/src/forms2/helpers/useFormControl.jsx
@@ -7,6 +7,12 @@ import { decode, getTargetValue, encode } from './form-helpers';
 
 import { FormContext } from './useFormHelper';
 
+/* O state é repassado como parâmetro para resolver problemas de renderização de um formulário
+   formado de "uncontrolled components".
+   Caso seja desejado usar este hook desassociado de um FormElement, isto é, fazer:
+    useFormControl2('nameNaoReferenciadoPorFormElement')
+  para alguma manipulação do valor do formData, o desenvolvedor precisa passar um state como parâmetro.
+*/
 export function useFormControl2(name, type, { state, afterSetValue } = {}) {
   const formHelper = useContext(FormContext);
 

--- a/src/forms2/helpers/useFormControl.jsx
+++ b/src/forms2/helpers/useFormControl.jsx
@@ -56,6 +56,14 @@ export function useFormControl2(name, type, { state, afterSetValue } = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (isRegistered && isFunction(setStateValue)) {
+      formHelper.setFormControl(name, {
+        setValue: setFormControlValue,
+      });
+    }
+  }, [formHelper, isRegistered, name, setFormControlValue, setStateValue]);
+
   const registerInputRef = useCallback(
     (ref) => {
       formHelper.registerRef(name, ref);

--- a/src/forms2/helpers/useFormHelper.jsx
+++ b/src/forms2/helpers/useFormHelper.jsx
@@ -27,6 +27,10 @@ export class FormHelper {
       formControl.setValue(value);
     }
 
+    this.setFormControl(name, formControl);
+  }
+
+  setFormControl(name, formControl) {
     this.formControls.set(name, formControl);
   }
 
@@ -112,6 +116,9 @@ export function useFormHelper(initialValues, { debounceWait, transform, onChange
       if (formControl) {
         formControl.setValue(value);
       }
+    },
+    setFormControl(name, formControl) {
+      formHelper.current.setFormControl(name, formControl);
     },
     getFormData() {
       return formHelper.current.formData;


### PR DESCRIPTION
Ajustes para corrigir um dos problemas descrito https://github.com/geolaborapp/geolabor/pull/5946

Quando a ficha começava desbloqueada, depois era bloqueada, as alterações na ficha não eram salvas. Isso porque, na lógica avaliarEnsaio/avaliarInvestigacao ainda estava falando que a entidade estava no modo "somenteLeitura".

Esse problema foi causada pelo fato do "setValue" do formControl não ser atualizado depois do registro inicial. A correção foi fazer com que esse setValue possa ser atualizado.

PS: não consegui pensar em uma forma excelente de traduzir esse comportamento da ficha no FormExample2.