### PR TITLE
fix: corrige invalid date ao limpar input datetime-local

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -37,7 +37,7 @@ export function FormExamples() {
         },
         dropdownField2: '03',
       }}
-      onChange={console.info}
+      onChange={(data) => console.log('onChange', data)}
       onSubmit={(formData) => {
         console.log('onSubmit', formData);
 

--- a/demo/UncontrolledFormExamples.jsx
+++ b/demo/UncontrolledFormExamples.jsx
@@ -115,6 +115,9 @@ export function UncontrolledFormExamples() {
           <label htmlFor="">Array of objects</label>
           <FormArrayOfObjects />
         </div>
+        <div className="mb-3">
+          <UncontrolledFormGroupInput label="Input date" name="inputDate" type="datetime-local" />
+        </div>
         <UncontrolledFormGroupAutocomplete
           name="autocomplete2Field1"
           label="Autocomplete Object Options"

--- a/src/forms/helpers/form-helpers.js
+++ b/src/forms/helpers/form-helpers.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isFunction, isUndefined, isArray, isObject, isEmptyStringLike, isBoolean } from 'js-var-type';
+import { isFunction, isUndefined, isArray, isObject, isEmptyStringLike, isBoolean, isDate } from 'js-var-type';
 
 import { getValueByPath } from '../../utils/getters-setters';
 import { fromDatetimeLocal, toDatetimeLocal } from '../../utils/formatters';
@@ -151,6 +151,14 @@ export function encode(value, type) {
   return value;
 }
 
+function isValidDate(date) {
+  if (!isDate(date) || isNaN(date.getDate()) || date.toString() === 'Invalid Date') {
+    return false;
+  }
+
+  return true;
+}
+
 export function decode(value, type) {
   if (type === 'number') {
     const parsedValue = parseFloat(value);
@@ -160,6 +168,10 @@ export function decode(value, type) {
 
   if (type === 'boolean') {
     return isBoolean(value) ? value : value === 'true';
+  }
+
+  if (type === 'datetime-local') {
+    return isValidDate(value) ? value : getEmptyValue(type);
   }
 
   return value;

--- a/src/uncontrolled-forms/helpers/form-helpers.js
+++ b/src/uncontrolled-forms/helpers/form-helpers.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isFunction, isUndefined, isArray, isObject, isEmptyStringLike, isBoolean } from 'js-var-type';
+import { isFunction, isUndefined, isArray, isObject, isEmptyStringLike, isBoolean, isDate } from 'js-var-type';
 
 import { getValueByPath } from '../../utils/getters-setters';
 import { fromDatetimeLocal, toDatetimeLocal } from '../../utils/formatters';
@@ -151,6 +151,14 @@ export function encode(value, type) {
   return value;
 }
 
+function isValidDate(date) {
+  if (!isDate(date) || isNaN(date.getDate()) || date.toString() === 'Invalid Date') {
+    return false;
+  }
+
+  return true;
+}
+
 export function decode(value, type) {
   if (type === 'number') {
     const parsedValue = parseFloat(value);
@@ -160,6 +168,10 @@ export function decode(value, type) {
 
   if (type === 'boolean') {
     return isBoolean(value) ? value : value === 'true';
+  }
+
+  if (type === 'datetime-local') {
+    return isValidDate(value) ? value : getEmptyValue(type);
   }
 
   return value;


### PR DESCRIPTION
card [[react-bootstrap-utils] Ao "clear" uma data, o valor no estado passa a ser "invalid date"](https://app.clickup.com/t/86a0ypq0b)

O bug acontecia nos dois forms

![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/db14844d-cb99-46ea-912e-3eb3559436a1)

---
### Para reproduzir o bug
1. Preencha um input datetime-local.
2. Clique em limpar