### PR TITLE
fix: corrige validação do form quando validations muda

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -19,6 +19,78 @@ import {
 
 export function FormExamples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
+  const [changeCustomValidation, setChangeCustomValidation] = useState(false);
+
+  const validations = useMemo(
+    () => ({
+      numberField: [
+        {
+          message: 'Must be filled if textField is not empty',
+          validate(value, formData) {
+            return !formData.textField || value;
+          },
+        },
+      ],
+      autocompleteField: [
+        {
+          message: 'Must be filled',
+          validate(value) {
+            return value;
+          },
+        },
+      ],
+      selectField: [
+        {
+          message: 'Must be filled if autocompleteField1 is empty',
+          validate(value, formData) {
+            return formData.autocompleteField1 || value;
+          },
+        },
+      ],
+      switchField: [
+        {
+          message: 'Must be filled if selectField is empty',
+          validate(value, formData) {
+            return formData.selectField || value;
+          },
+        },
+      ],
+      checkboxField: [
+        {
+          message: 'Must be filled if switchField is empty',
+          validate(value, formData) {
+            return formData.switchField || value;
+          },
+        },
+      ],
+      radioField: [
+        {
+          message: 'Must be filled if checkboxField is empty',
+          validate(value, formData) {
+            return formData.checkboxField || value;
+          },
+        },
+      ],
+      textareaField: [
+        {
+          message: 'Must be filled if radioField is empty',
+          validate(value, formData) {
+            return formData.radioField || value;
+          },
+        },
+      ],
+      variableValidationTest: [
+        {
+          message: `Must be filled with "${changeCustomValidation ? 'b' : 'a'}"`,
+          validate(value, formData) {
+            return changeCustomValidation ? value === 'b' : value === 'a';
+          },
+        },
+      ],
+    }),
+    [changeCustomValidation]
+  );
+
   return (
     <Form
       initialValues={{
@@ -57,64 +129,7 @@ export function FormExamples() {
         resetForm();
       }}
       customValidation={bootstrapFormValidation}
-      validations={{
-        numberField: [
-          {
-            message: 'Must be filled if textField is not empty',
-            validate(value, formData) {
-              return !formData.textField || value;
-            },
-          },
-        ],
-        autocompleteField: [
-          {
-            message: 'Must be filled',
-            validate(value) {
-              return value;
-            },
-          },
-        ],
-        selectField: [
-          {
-            message: 'Must be filled if autocompleteField1 is empty',
-            validate(value, formData) {
-              return formData.autocompleteField1 || value;
-            },
-          },
-        ],
-        switchField: [
-          {
-            message: 'Must be filled if selectField is empty',
-            validate(value, formData) {
-              return formData.selectField || value;
-            },
-          },
-        ],
-        checkboxField: [
-          {
-            message: 'Must be filled if switchField is empty',
-            validate(value, formData) {
-              return formData.switchField || value;
-            },
-          },
-        ],
-        radioField: [
-          {
-            message: 'Must be filled if checkboxField is empty',
-            validate(value, formData) {
-              return formData.checkboxField || value;
-            },
-          },
-        ],
-        textareaField: [
-          {
-            message: 'Must be filled if radioField is empty',
-            validate(value, formData) {
-              return formData.radioField || value;
-            },
-          },
-        ],
-      }}
+      validations={validations}
     >
       <h5>Form configuration:</h5>
       <FormGroupSwitch
@@ -123,7 +138,23 @@ export function FormExamples() {
         label="Use bootstrap form validation?"
         afterChange={(value) => setBootstrapFormValidation(value)}
       />
+      <FormGroupSwitch
+        id="changeVariableCustomValidation"
+        name="changeVariableCustomValidation"
+        label="Change validation for variable custom validation?"
+        afterChange={(value) => setChangeCustomValidation(value)}
+      />
       <hr />
+      <div className="row">
+        <div className="col">
+          <FormGroupInput
+            name="variableCustomValidation"
+            label="Variable custom validation"
+            placeholder={'Type "a" or "b"'}
+            help={'if "Change validation for variable custom validation" is not setted this should be "a" else "b" '}
+          />
+        </div>
+      </div>
       <div className="row">
         <div className="col">
           <FormGroupInput name="textField" label="Text field" disabled help="Text field help" />

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -79,7 +79,7 @@ export function FormExamples() {
           },
         },
       ],
-      variableValidationTest: [
+      variableCustomValidation: [
         {
           message: `Must be filled with "${changeCustomValidation ? 'b' : 'a'}"`,
           validate(value, formData) {

--- a/src/forms/helpers/useForm.js
+++ b/src/forms/helpers/useForm.js
@@ -136,6 +136,7 @@ export function useForm(initialState, { validations, onChange, transform }) {
       return submitAttempted;
     },
     getValidationMessage,
+    validateForm,
   };
 }
 

--- a/src/forms/helpers/useForm.js
+++ b/src/forms/helpers/useForm.js
@@ -1,5 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { debounce } from 'lodash-es';
+
+import { isFunction } from 'js-var-type';
 
 import { useArrayValueMap } from '../../utils/useValueMap';
 import { setValueByPath, deepClone, getValueByPath } from '../../utils/getters-setters';
@@ -52,52 +54,12 @@ function useFormState(initialState, { onChange, transform }) {
 export function useForm(initialState, { validations, onChange, transform }) {
   const { getState, updateState, resetState } = useFormState(initialState, { onChange, transform });
   const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [, setRefreshForm] = useState(false);
   const { getAllKeys: getElementNames, get: getElementRefs, push: registerElementRef } = useArrayValueMap();
 
   const formState = getState();
-
-  return {
-    register(name, elementRef) {
-      registerElementRef(name, elementRef);
-
-      if (validations) {
-        validateFormElement({
-          name,
-          formData: formState,
-          validations: validations[name],
-          elementRefs: [elementRef],
-        });
-      }
-    },
-    update(name, value) {
-      updateState(name, value);
-
-      if (validations) {
-        this.validateForm(nextState(formState, name, value));
-      }
-    },
-    getFormData() {
-      return formState;
-    },
-    getValue(name) {
-      return getValueByPath(formState, name);
-    },
-    reset() {
-      resetState();
-      setSubmitAttempted(false);
-    },
-    setSubmitedAttempted() {
-      setSubmitAttempted(true);
-    },
-    getSubmitedAttempted() {
-      return submitAttempted;
-    },
-    getValidationMessage(name) {
-      const elementRefs = getElementRefs(name);
-
-      return elementRefs && elementRefs[0] ? elementRefs[0].validationMessage : '';
-    },
-    validateForm(_formData) {
+  const validateForm = useCallback(
+    (_formData) => {
       const elementNames = getElementNames();
       let isFormValid = true;
       const formData = _formData || formState;
@@ -117,6 +79,63 @@ export function useForm(initialState, { validations, onChange, transform }) {
 
       return isFormValid;
     },
+    [formState, getElementNames, getElementRefs, validations]
+  );
+
+  const getValidationMessage = useCallback(
+    (name) => {
+      const elementRefs = getElementRefs(name);
+
+      return elementRefs && elementRefs[0] ? elementRefs[0].validationMessage : '';
+    },
+    [getElementRefs]
+  );
+
+  useEffect(() => {
+    if (validations && isFunction(validateForm)) {
+      validateForm();
+      setRefreshForm((v) => !v);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [validations]);
+
+  return {
+    register(name, elementRef) {
+      registerElementRef(name, elementRef);
+
+      if (validations) {
+        validateFormElement({
+          name,
+          formData: formState,
+          validations: validations[name],
+          elementRefs: [elementRef],
+        });
+      }
+    },
+    update(name, value) {
+      updateState(name, value);
+
+      if (validations) {
+        validateForm(nextState(formState, name, value));
+      }
+    },
+    getFormData() {
+      return formState;
+    },
+    getValue(name) {
+      return getValueByPath(formState, name);
+    },
+    reset() {
+      resetState();
+      setSubmitAttempted(false);
+    },
+    setSubmitedAttempted() {
+      setSubmitAttempted(true);
+    },
+    getSubmitedAttempted() {
+      return submitAttempted;
+    },
+    getValidationMessage,
   };
 }
 


### PR DESCRIPTION
### card [Ajustar validação no RCA para evitar usar o array de mobilizações do colaborador](https://app.clickup.com/t/86a1fuqgw)

### Descrição
Este PR tem a intenção de corrigir um problema que acontece quando estamos usando `customValidations` no `Form` e o `validations` sofre uma alteração.

### O problema

https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/2cd4d12b-8985-4b0f-8ad3-bf18cb9f11e4

### Depois da correção

https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/c0c98339-6a12-488b-9893-8161e52e5929


### Ao revisor
Percebi esse problema enquanto estava tentando alterar a validação do campo "coletaRealizadaPor" no form de edição de registro de campo de amostra do geolabor. A ideia era passar os colaboradores mobilizados carregados pelo redux na função de validação no "validations" do Form, para conseguir verificar se os colaboradores no Form estava mobilizados ou não sem usar o array de mobilizações, para padronizar com o que passou a ser feito no https://github.com/geolaborapp/geolabor/pull/6083.

A ideia da correção é usar um useEffect para rodar a validação, sempre que o "validations" for alterado. Com apenas esse useEffect não foi possivel resolver o problema, porque o input estava ficando invalido corretamente, mas o feedback não aparecia no Form, por esse motivo adicionei um useState para forçar o feedback a aparecer caso a ficha tenha o "validations" alterado.