### PR TITLE
fix: corrige uso de label de tag e melhora uso do trackBy no FormAutocompleteTag

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -304,20 +304,7 @@ export function FormExamples() {
             repeatedTagErrorMessage="Impossible to add repeated tag"
             addButtonIcon={<i className="bi bi-person-add" />}
             removeButtonIcon={<i className="bi bi-person-dash" />}
-            options={[
-              {
-                label: '1',
-                value: '1',
-              },
-              {
-                label: 'tag',
-                value: 'tag',
-              },
-              {
-                label: 'preSelected',
-                value: 'preSelected',
-              },
-            ]}
+            options={['1', 'tag', 'preSelected']}
             allowRemove
             openOnFocus
             help="Add at least one tag to this field"
@@ -367,6 +354,9 @@ export function FormExamples() {
               {
                 label: 'preSelected',
                 _id: '3',
+              },
+              {
+                _id: '4',
               },
             ]}
             allowUnlistedValue={false}


### PR DESCRIPTION
### card [Correções no FormGroupAutocompleteTag](https://app.clickup.com/t/86a1hzze0)

## Sobre o PR
Durante a execução do card [Atualizar Filtros e implementar o autocomplete com scroll ininito como opção](https://app.clickup.com/t/86a0v3503), percebi alguns problemas com o FormAutocompleteTag e FormGroupAutocompleteTag:
- Passando um array de objetos para o "options", cada objeto deveria ter um "label", se não tivesse aconteceria um erro ""de react"" ao tentar exibir um objeto(no geolabor era uma tela do oops)
- O "allowUnlisted" values estava com um funcionamento estranho quando usado em conjunto com o "trackBy", ao adicionar um novo valor, era criado um objeto com "label" e "value", o correto seria usar o atributo no "trackBy" no lugar do "value"