### PR TITLE
fix: Corrige exibição do FormInputMask2 ao carregar valor inicial

### DIFF
--- a/src/forms2/helpers/useFormControl.jsx
+++ b/src/forms2/helpers/useFormControl.jsx
@@ -34,8 +34,12 @@ export function useFormControl2(name, type, { state, afterSetValue } = {}) {
       const nextValue = getNextValue(newValue);
 
       setStateValue?.(isDefined(nextValue) ? nextValue : '');
+
+      if (isFunction(afterSetValue)) {
+        afterSetValue(nextValue);
+      }
     },
-    [getNextValue, setStateValue]
+    [afterSetValue, getNextValue, setStateValue]
   );
 
   const setFormControlValue = useCallback(


### PR DESCRIPTION
### card [Informações da investigação não estão sendo exibidas na ficha (Geolabor clássico) ](https://app.clickup.com/t/86a1kuxmd)

### Descrição
O problema estava acontecendo nas fichas do geolabor, em campos de numero e data, que usam o "FormInputMask/FormGroupInputMask", ao carregar o Form2 com valores iniciais para esses campos, o valor estava preenchido no Form2 mas não era visivel.
Analisando mais a fundo, percebi que a alteração no PR https://github.com/geolaborapp/react-bootstrap-utils/pull/59 pode ter causado esse bug, porque o "afterSetValue" não estava sendo disparado na primeira renderização.

### Para o revisor
Vamos precisar gerar uma versão 0.26.47-2, porque as versões 0.26.48+ contem breaking changes(o Form2 foi renomeado para UncontrolledForm)