### PR TITLE
feat: facilita adicionar classes em FormInput, UncontrolledFormInput e UncontrolledFormInputMask

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -166,6 +166,7 @@ export function FormExamples() {
             required
             placeholder="Fill some value"
             afterChange={console.log.bind(console, 'afterChange input')}
+            inputClassName={'text-danger text-uppercase'}
           />
         </div>
         <div className="col">

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -166,7 +166,7 @@ export function FormExamples() {
             required
             placeholder="Fill some value"
             afterChange={console.log.bind(console, 'afterChange input')}
-            inputClassName={'text-danger text-uppercase'}
+            inputClassName="text-danger text-uppercase"
           />
         </div>
         <div className="col">

--- a/demo/UncontrolledFormExamples.jsx
+++ b/demo/UncontrolledFormExamples.jsx
@@ -170,7 +170,11 @@ export function UncontrolledFormExamples() {
         />
 
         <UncontrolledFormGroupInput label="AttrA" name="attrA"></UncontrolledFormGroupInput>
-        <UncontrolledFormGroupInput label="AttrB" name="attrB"></UncontrolledFormGroupInput>
+        <UncontrolledFormGroupInput
+          label="AttrB"
+          name="attrB"
+          inputClassName={'text-danger text-uppercase'}
+        ></UncontrolledFormGroupInput>
         <UncontrolledFormGroupSelect label="AttrC" name="attrC" options={[1, 2, 3]}></UncontrolledFormGroupSelect>
         <UncontrolledFormGroupSwitch id="attrD" label="AttrD" name="attrD"></UncontrolledFormGroupSwitch>
 
@@ -253,6 +257,18 @@ export function UncontrolledFormExamples() {
           mask={{
             parse: currencyMask,
             format: (value) => value,
+          }}
+        />
+
+        <UncontrolledFormGroupInputMask
+          name="maskWithCustomCss"
+          inputAttrs={{
+            inputClassName: 'text-danger text-uppercase',
+          }}
+          label="Mask with custom classes"
+          mask={{
+            parse: (v) => ({ rawValue: v, maskedValue: v }),
+            format: (v) => v,
           }}
         />
 

--- a/demo/UncontrolledFormExamples.jsx
+++ b/demo/UncontrolledFormExamples.jsx
@@ -173,7 +173,7 @@ export function UncontrolledFormExamples() {
         <UncontrolledFormGroupInput
           label="AttrB"
           name="attrB"
-          inputClassName={'text-danger text-uppercase'}
+          inputClassName="text-danger text-uppercase"
         ></UncontrolledFormGroupInput>
         <UncontrolledFormGroupSelect label="AttrC" name="attrC" options={[1, 2, 3]}></UncontrolledFormGroupSelect>
         <UncontrolledFormGroupSwitch id="attrD" label="AttrD" name="attrD"></UncontrolledFormGroupSwitch>

--- a/src/dialog/Dialog.jsx
+++ b/src/dialog/Dialog.jsx
@@ -36,7 +36,7 @@ export function Dialog({ children, onlyRenderContentIfIsOpen, onClose, ...props 
   const onCloseDialog = async () => {
     await onClose();
     close();
-  }
+  };
 
   return (
     <React.Fragment>

--- a/src/forms/FormInput.jsx
+++ b/src/forms/FormInput.jsx
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import { useFormControl } from './helpers/useFormControl';
 import { booleanOrFunction } from './helpers/form-helpers';
 import { FormGroup } from './FormGroup';
+import { formatClasses } from '../utils/attributes';
 
-export function FormInput({ type, name, required: _required, disabled: _disabled, afterChange, ..._attrs }) {
+export function FormInput({ type, name, required: _required, disabled: _disabled, afterChange, inputClassName,..._attrs }) {
   const { getValue, handleOnChangeFactory, register, getFormData } = useFormControl(name, type);
   const registerRef = useCallback(register, [register]);
   const disabled = booleanOrFunction(_disabled, getFormData());
@@ -25,7 +26,7 @@ export function FormInput({ type, name, required: _required, disabled: _disabled
     attrs.value = getValue();
   }
 
-  return <input className="form-control" {...attrs} onChange={handleOnChangeFactory(afterChange)} ref={registerRef} />;
+  return <input className={formatClasses(["form-control",inputClassName])} {...attrs} onChange={handleOnChangeFactory(afterChange)} ref={registerRef} />;
 }
 
 FormInput.defaultProps = {
@@ -36,6 +37,7 @@ FormInput.propTypes = {
   afterChange: PropTypes.func,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   id: PropTypes.string,
+  inputClassName:PropTypes.string,
   max: PropTypes.string,
   maxLength: PropTypes.string,
   min: PropTypes.string,
@@ -62,6 +64,7 @@ FormGroupInput.propTypes = {
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   help: PropTypes.node,
   id: PropTypes.string,
+  inputClassName:PropTypes.string,
   label: PropTypes.node.isRequired,
   max: PropTypes.string,
   maxLength: PropTypes.string,

--- a/src/forms/FormInput.jsx
+++ b/src/forms/FormInput.jsx
@@ -1,12 +1,21 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
+import { formatClasses } from '../utils/attributes';
+
 import { useFormControl } from './helpers/useFormControl';
 import { booleanOrFunction } from './helpers/form-helpers';
 import { FormGroup } from './FormGroup';
-import { formatClasses } from '../utils/attributes';
 
-export function FormInput({ type, name, required: _required, disabled: _disabled, afterChange, inputClassName,..._attrs }) {
+export function FormInput({
+  type,
+  name,
+  required: _required,
+  disabled: _disabled,
+  afterChange,
+  inputClassName,
+  ..._attrs
+}) {
   const { getValue, handleOnChangeFactory, register, getFormData } = useFormControl(name, type);
   const registerRef = useCallback(register, [register]);
   const disabled = booleanOrFunction(_disabled, getFormData());
@@ -26,7 +35,14 @@ export function FormInput({ type, name, required: _required, disabled: _disabled
     attrs.value = getValue();
   }
 
-  return <input className={formatClasses(["form-control",inputClassName])} {...attrs} onChange={handleOnChangeFactory(afterChange)} ref={registerRef} />;
+  return (
+    <input
+      className={formatClasses(['form-control', inputClassName])}
+      {...attrs}
+      onChange={handleOnChangeFactory(afterChange)}
+      ref={registerRef}
+    />
+  );
 }
 
 FormInput.defaultProps = {
@@ -37,7 +53,7 @@ FormInput.propTypes = {
   afterChange: PropTypes.func,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   id: PropTypes.string,
-  inputClassName:PropTypes.string,
+  inputClassName: PropTypes.string,
   max: PropTypes.string,
   maxLength: PropTypes.string,
   min: PropTypes.string,
@@ -64,7 +80,7 @@ FormGroupInput.propTypes = {
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   help: PropTypes.node,
   id: PropTypes.string,
-  inputClassName:PropTypes.string,
+  inputClassName: PropTypes.string,
   label: PropTypes.node.isRequired,
   max: PropTypes.string,
   maxLength: PropTypes.string,

--- a/src/uncontrolled-forms/UncontrolledFormInput.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormInput.jsx
@@ -5,6 +5,7 @@ import { booleanOrFunction } from './helpers/form-helpers';
 
 import { useUncontrolledFormControl } from './helpers/useUncontrolledFormControl';
 import { UncontrolledFormGroup } from './UncontrolledFormGroup';
+import { formatClasses } from '../utils/attributes';
 
 export function UncontrolledFormInput({
   type,
@@ -12,6 +13,7 @@ export function UncontrolledFormInput({
   required: _required,
   disabled: _disabled,
   afterChange,
+  inputClassName,
   ..._attrs
 }) {
   const state = useState('');
@@ -39,7 +41,7 @@ export function UncontrolledFormInput({
 
   return (
     <input
-      className="form-control"
+      className={formatClasses(['form-control', inputClassName])}
       {...attrs}
       onChange={handleOnChangeFactory(afterChange, type)}
       ref={registerInputRef}
@@ -55,6 +57,7 @@ UncontrolledFormInput.propTypes = {
   afterChange: PropTypes.func,
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   id: PropTypes.string,
+  inputClassName: PropTypes.string,
   max: PropTypes.string,
   maxLength: PropTypes.string,
   min: PropTypes.string,
@@ -81,6 +84,7 @@ UncontrolledFormGroupInput.propTypes = {
   disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   help: PropTypes.node,
   id: PropTypes.string,
+  inputClassName: PropTypes.string,
   label: PropTypes.node.isRequired,
   max: PropTypes.string,
   maxLength: PropTypes.string,

--- a/src/uncontrolled-forms/UncontrolledFormInput.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormInput.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
+import { formatClasses } from '../utils/attributes';
+
 import { booleanOrFunction } from './helpers/form-helpers';
 
 import { useUncontrolledFormControl } from './helpers/useUncontrolledFormControl';
 import { UncontrolledFormGroup } from './UncontrolledFormGroup';
-import { formatClasses } from '../utils/attributes';
 
 export function UncontrolledFormInput({
   type,

--- a/src/uncontrolled-forms/UncontrolledFormInputMask.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormInputMask.jsx
@@ -2,6 +2,8 @@ import React, { useRef, useCallback, useState } from 'react';
 import { isUndefined } from 'js-var-type';
 import PropTypes from 'prop-types';
 
+import { formatClasses } from '../utils/attributes';
+
 import { useUncontrolledFormControl } from './helpers/useUncontrolledFormControl';
 import { UncontrolledFormInput } from './UncontrolledFormInput';
 import { UncontrolledFormGroup } from './UncontrolledFormGroup';
@@ -9,7 +11,7 @@ import { UncontrolledFormGroup } from './UncontrolledFormGroup';
 export function UncontrolledFormInputMask({ mask, name, inputAttrs }) {
   const state = useState('');
   const ref = useRef(null);
-  const { afterChange, ..._inputAttrs } = inputAttrs;
+  const { afterChange, inputClassName, ..._inputAttrs } = inputAttrs;
 
   const setFormattedValue = useCallback((value) => {
     const valueFormatado = mask?.format?.(value) ?? value;
@@ -43,7 +45,7 @@ export function UncontrolledFormInputMask({ mask, name, inputAttrs }) {
     <>
       <input
         ref={ref}
-        className="form-control"
+        className={formatClasses(['form-control', inputClassName])}
         name={`__mask.${name}`}
         defaultValue=""
         onChange={(e) => {
@@ -98,6 +100,7 @@ UncontrolledFormGroupInputMask.propTypes = {
     disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     help: PropTypes.node,
     id: PropTypes.string,
+    inputClassName: PropTypes.string,
     max: PropTypes.string,
     maxLength: PropTypes.string,
     min: PropTypes.string,


### PR DESCRIPTION
No https://github.com/geolaborapp/geolabor/pull/6724 foi percebido que para passar classes para inputs do RBU, era sempre necessario definir a classe "form-control" junto com as novas classes.
![image](https://github.com/assisrafael/react-bootstrap-utils/assets/68669058/2fa228c1-872a-47ac-801d-685992f8eb17)

Acredito que ter que sempre reescrever uma classe não seja o ideal, então minha ideia foi fazer como é feito em outros componentes do RBU como o dropdown, e usar props para montar a classe no input.

UncontrolledFormGroupInputMask
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/f6f3b7b3-bbd0-4867-bbb4-de10ea8d1b88)

UncontrolledFormGroupInput
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/8fe40098-3689-476b-8aa7-bf3582e6b2d1)

FormGroupInput
![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/5fe5262c-ab8c-4230-bd6a-464b91865d94)

