### PR TITLE
feat: Possibilita passar um formatador para mensagens dos toasts

### DIFF
--- a/demo/ToastsWithMessageFormatterExamples.jsx
+++ b/demo/ToastsWithMessageFormatterExamples.jsx
@@ -1,0 +1,17 @@
+import React, { useCallback } from 'react';
+// eslint-disable-next-line import/no-unresolved
+import { ToastsContainer } from '../dist/main';
+import { ToastsExamples } from './ToastsExamples';
+
+export function ToastsWithMessageFormatterExamples() {
+  const messageFormatter = useCallback((message) => `Text added on formatter + ${message}`);
+
+  return (
+    <div className="row">
+      Toasts with text prepended
+      <ToastsContainer messageFormatter={messageFormatter}>
+        <ToastsExamples />
+      </ToastsContainer>
+    </div>
+  );
+}

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -15,6 +15,7 @@ import { ToastsExamples } from './ToastsExamples';
 import { DropdownExamples } from './DropdownExamples';
 import { TreeViewExamples } from './TreeViewExamples';
 import { UncontrolledFormExamples } from './UncontrolledFormExamples';
+import { ToastsWithMessageFormatterExamples } from './ToastsWithMessageFormatterExamples';
 
 ReactDOM.render(
   <div className="mt-3">
@@ -67,6 +68,10 @@ ReactDOM.render(
                 <ToastsExamples />
               </ToastsContainer>
             ),
+          },
+          {
+            title: 'Toasts with message formatter',
+            content: <ToastsWithMessageFormatterExamples />,
           },
           {
             title: 'TreeView',

--- a/src/toasts/ToastsContainer.jsx
+++ b/src/toasts/ToastsContainer.jsx
@@ -5,8 +5,8 @@ import { ToastsContext, TOASTS_VALID_POSITIONS } from './toasts-helpers';
 import { ToastsRegion } from './ToastsRegion';
 import { useToastState } from './useToastState';
 
-export function ToastsContainer({ children, unique, noStyle }) {
-  const toastsState = useToastState({ unique });
+export function ToastsContainer({ children, unique, noStyle, messageFormatter }) {
+  const toastsState = useToastState({ unique, messageFormatter });
 
   return (
     <ToastsContext.Provider value={toastsState}>
@@ -30,4 +30,5 @@ ToastsContainer.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   noStyle: PropTypes.bool,
   unique: PropTypes.bool,
+  messageFormatter: PropTypes.func,
 };

--- a/src/toasts/useToastState.js
+++ b/src/toasts/useToastState.js
@@ -1,11 +1,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { isNumber } from 'js-var-type';
+import { isFunction, isNumber } from 'js-var-type';
 
 import { useArrayValueMap } from '../utils/useValueMap';
 
 import { TOASTS_VALID_TYPES, TOASTS_VALID_POSITIONS } from './toasts-helpers';
 
-export function useToastState({ unique }) {
+export function useToastState({ unique, messageFormatter }) {
   const [nextId, setNextId] = useState(0);
   const timeoutRefs = useRef({});
 
@@ -26,10 +26,11 @@ export function useToastState({ unique }) {
       }
 
       const toastId = nextId;
+      const _message = isFunction(messageFormatter) ? messageFormatter(message) : message;
 
       push(position, {
         id: toastId,
-        message,
+        message: _message,
         type,
         position,
         closeControl: !autoClose,
@@ -47,7 +48,7 @@ export function useToastState({ unique }) {
 
       return toastId;
     },
-    [close, nextId, push]
+    [close, messageFormatter, nextId, push]
   );
 
   const close = useCallback(


### PR DESCRIPTION
Este PR tem a intenção de possibilitar passar um formatador para mensagens nos toasts.
A ideia dessa PR surgiu da necessidade de substituir mensagens de erro do nginx no geolabor que estavam aparecendo nos toasts. Com este PR podemos lidar com todos os usos dos toasts do rbu apenas passando o formatador

![image](https://github.com/geolaborapp/react-bootstrap-utils/assets/68669058/59b4bc96-6c69-42cd-b967-5f889e0df7cf)

