### PR TITLE
feat: Permite não passar a propriedade message nas validations do Form

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -114,6 +114,13 @@ export function FormExamples() {
             },
           },
         ],
+        undefinedMessageField: [
+          {
+            validate(value, formData) {
+              return formData.undefinedMessageField || value;
+            },
+          },
+        ],
       }}
     >
       <h5>Form configuration:</h5>
@@ -561,6 +568,8 @@ export function FormExamples() {
         afterChange={console.log.bind(console, 'afterChange textarea')}
       />
       <FormGroupTextarea name="textareaField2" label="Textarea field 2" disabled rows="1" />
+
+      <FormGroupTextarea name="undefinedMessageField" label="Undefined message field" rows="1" />
 
       {[0, 1].map((index) => (
         <div className="row" key={index}>

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -89,8 +89,8 @@ export function FormExamples() {
       ],
       undefinedMessageField: [
         {
-          validate(value, formData) {
-            return formData.undefinedMessageField || value;
+          validate(value) {
+            return value;
           },
         },
       ],

--- a/src/forms/FormValidationFeedback.jsx
+++ b/src/forms/FormValidationFeedback.jsx
@@ -1,11 +1,16 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import { isEmptyLike } from 'js-var-type';
 
 import { FormContext } from './helpers/form-helpers';
 
 export function FormValidationFeedback({ name, mockInvalidSibling }) {
   const formState = useContext(FormContext);
-  const validationMessage = formState.getValidationMessage(name);
+  let validationMessage = formState.getValidationMessage(name);
+
+  if (validationMessage === 'undefined' || validationMessage === 'null' || isEmptyLike(validationMessage)) {
+    validationMessage = '';
+  }
 
   return (
     <>


### PR DESCRIPTION
Este PR tornou-se necessário na implementação da customValidation dos campos de filtros do mapa de servicos-campo. A ideia é reproduzir o comportamento antigo (porém com o custom validation), em que a mensagem de erro de validação de 3 campos era exibida apenas em 1:
![Captura de tela de 2025-02-19 09-51-55](https://github.com/user-attachments/assets/f0d282e0-ddf9-44b5-8d83-6f4c3f6f2706)
Para isso foi preciso que os campos Contrato e Campanha não tivessem mensagens de validação. No entanto o Form do rbu não permitia não passar a propriedade 'message', então o objetivo desse PR é passar a permitir a ausência dessa prop, exibindo uma string vazia quando não passada.