### PR TITLE
fix: corrige exibição de campos autocomplete usando o "value" no template

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -105,6 +105,7 @@ export function FormExamples() {
         autocompleteField1: { _id: '2345', name: '2345 name' },
         autocompleteField4: 'unlisted item',
         autocompleteTag2: [{ label: 'preSelected', value: 'preSelected' }],
+        autocompleteField6: { _id: '2' },
         selectField4: { e: 2, c: 'b' },
         switchField2: true,
         checkboxField2: true,
@@ -284,6 +285,57 @@ export function FormExamples() {
             onClearSearch={() => {
               console.log('search has been cleared');
             }}
+          />
+        </div>
+        <div className="col">
+          <FormGroupAutocomplete
+            name="autocompleteField6"
+            label="Autocomplete with custom template"
+            options={[
+              {
+                label: 'value that can be searched',
+                value: {
+                  attribute1: 'value',
+                  attribute2: 'that can',
+                  attribute3: 'be searched',
+                  _id: '1',
+                },
+              },
+              {
+                label: 'another value that can be searched',
+                value: {
+                  attribute1: 'another value',
+                  attribute2: 'that can',
+                  attribute3: 'be searched',
+                  _id: '2',
+                },
+              },
+              {
+                label: 'something that can be searched',
+                value: {
+                  attribute1: 'something',
+                  attribute2: 'that can',
+                  attribute3: 'be searched',
+                  _id: '3',
+                },
+              },
+            ]}
+            trackBy="_id"
+            placeholder="Type to search in the available options"
+            afterChange={(newValue, oldValue) => {
+              console.log('autocompleteField6: ', oldValue, ' changed to  :>> ', newValue);
+            }}
+            onClearSearch={() => {
+              console.log('search has been cleared');
+            }}
+            template={(label, value) => (
+              <div className="d-flex flex-column py-1">
+                <div>{value?.attribute1}</div>
+                <em>{value?.attribute2}</em>
+                <div>{value?.attribute3}</div>
+              </div>
+            )}
+            openOnFocus
           />
         </div>
       </div>

--- a/demo/UncontrolledFormExamples.jsx
+++ b/demo/UncontrolledFormExamples.jsx
@@ -33,6 +33,7 @@ export function UncontrolledFormExamples() {
           Obj: { x: 'X', z: 0 },
           arr: [1, 2, 3, 4, 5],
           arrObj: [{ o: 1 }, { o: 2 }, { o: 3 }],
+          autocomplete2Field5: { _id: '2' },
           textarea1:
             'Lorem ipsum dolor sit amet consectetur adipisicing elit. Atque praesentium quisquam reiciendis expedita. Ad quod voluptas aliquid illum veniam odio? Nulla sed, illum eligendi amet fuga optio officia itaque nisi',
           dateMask: '0410202',
@@ -167,6 +168,56 @@ export function UncontrolledFormExamples() {
           onClearSearch={() => {
             console.log('search has been cleared');
           }}
+        />
+
+        <UncontrolledFormGroupAutocomplete
+          name="autocomplete2Field5"
+          label="Autocomplete with custom template"
+          options={[
+            {
+              label: 'value that can be searched',
+              value: {
+                attribute1: 'value',
+                attribute2: 'that can',
+                attribute3: 'be searched',
+                _id: '1',
+              },
+            },
+            {
+              label: 'another value that can be searched',
+              value: {
+                attribute1: 'another value',
+                attribute2: 'that can',
+                attribute3: 'be searched',
+                _id: '2',
+              },
+            },
+            {
+              label: 'something that can be searched',
+              value: {
+                attribute1: 'something',
+                attribute2: 'that can',
+                attribute3: 'be searched',
+                _id: '3',
+              },
+            },
+          ]}
+          trackBy="_id"
+          placeholder="Type to search in the available options"
+          afterChange={(newValue, oldValue) => {
+            console.log(oldValue, ' changed to  :>> ', newValue);
+          }}
+          onClearSearch={() => {
+            console.log('search has been cleared');
+          }}
+          template={(label, value) => (
+            <div className="d-flex flex-column py-1">
+              <div>{value?.attribute1}</div>
+              <em>{value?.attribute2}</em>
+              <div>{value?.attribute3}</div>
+            </div>
+          )}
+          openOnFocus
         />
 
         <UncontrolledFormGroupInput label="AttrA" name="attrA"></UncontrolledFormGroupInput>

--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -229,7 +229,11 @@ export function FormAutocomplete({
           disabled={disabled}
           onClick={enableSearchInput}
         >
-          {selectedItem ? (template ? template(selectedItem.label) : selectedItem.label) : placeholder}
+          {selectedItem
+            ? template
+              ? template(selectedItem?.label, selectedItem?.value)
+              : selectedItem?.label
+            : placeholder}
         </div>
       )}
 

--- a/src/uncontrolled-forms/UncontrolledFormAutocomplete.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormAutocomplete.jsx
@@ -224,7 +224,11 @@ export function UncontrolledFormAutocomplete({
           disabled={disabled}
           onClick={enableSearchInput}
         >
-          {selectedItem ? (template ? template(selectedItem.label) : selectedItem.label) : placeholder}
+          {selectedItem
+            ? template
+              ? template(selectedItem?.label, selectedItem?.value)
+              : selectedItem?.label
+            : placeholder}
         </div>
       )}
 


### PR DESCRIPTION
Correção para um problema percebido no geolabor.
Quando usamos o autocomplete com o template, e o template usa o "value", o campo não estava mostrando o valor selecionado usando a formatação
Ex:

[Gravação de tela de 2025-04-01 14-11-37.webm](https://github.com/user-attachments/assets/f54a6134-d402-4a8a-8016-de7d2e83eeb6)

Depois da correção

[Gravação de tela de 2025-04-01 14-12-43.webm](https://github.com/user-attachments/assets/192c2b67-3556-4857-b52e-f7821e1ae8ac)

card https://app.clickup.com/t/86a6g41hd