### PR TITLE
fix():Ajusta proptypes da tabela

### DIFF
--- a/demo/TableExamples.jsx
+++ b/demo/TableExamples.jsx
@@ -222,6 +222,7 @@ export function TableExamples() {
                 title: 'Subtract',
                 content: <span>{doc.b - docIndex}?</span>,
               },
+              (doc, index) => <span>{`${doc.c}-${index}`}</span>,
             ]}
           />
         </div>

--- a/src/table/Table.jsx
+++ b/src/table/Table.jsx
@@ -62,8 +62,7 @@ Table.propTypes = {
   actionLabel: PropTypes.string,
   actions: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.arrayOf(PropTypes.func),
-    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
   ]),
   bordered: PropTypes.bool,
   caption: PropTypes.node,

--- a/src/table/TableActions.jsx
+++ b/src/table/TableActions.jsx
@@ -31,8 +31,7 @@ TableActions.propTypes = {
   docIndex: PropTypes.number.isRequired,
   actions: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.arrayOf(PropTypes.func),
-    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
   ]),
 };
 

--- a/src/table/TableBody.jsx
+++ b/src/table/TableBody.jsx
@@ -44,8 +44,7 @@ export function TableBody({ columns, docs, rowRole, rowClass, actions, onRowClic
 TableBody.propTypes = {
   actions: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.arrayOf(PropTypes.func),
-    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object])),
   ]),
   columns: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object])),
   docs: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
No https://github.com/geolaborapp/geolabor/pull/8710 foi usada uma tabela com os actions sendo um array de funções, coisa que o RBU suporta, mas o proptypes reclamou, este PR é um ajuste para corrigir esse [log de erro](https://github.com/geolaborapp/geolabor/pull/8710/files/53ea28b6dcc9911aec5d71e6fd49e7a88270ef12#diff-0435286e139a3038585100788036395c63eefde5cfcab9f4789ad7050a43288f)

![image](https://github.com/user-attachments/assets/beed48a9-5ddd-4a4d-a988-8d71e6aa8c2c)
