### PR TITLE
feat: exporta função de reset form

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -21,6 +21,7 @@ export function FormExamples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   const [changeCustomValidation, setChangeCustomValidation] = useState(false);
   const [useCustomActions, setUseCustomActions] = useState(false);
+  console.log('🚀 ~ FormExamples ~ useCustomActions:', useCustomActions);
 
   const validations = useMemo(
     () => ({

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -20,6 +20,7 @@ import {
 export function FormExamples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   const [changeCustomValidation, setChangeCustomValidation] = useState(false);
+  const [useCustomActions, setUseCustomActions] = useState(false);
 
   const validations = useMemo(
     () => ({
@@ -138,6 +139,20 @@ export function FormExamples() {
       }}
       customValidation={bootstrapFormValidation}
       validations={validations}
+      customActions={
+        useCustomActions
+          ? (isSubmiting, { onCancel, resetForm }) => (
+              <div>
+                <button type="submit" className="btn btn-success">
+                  Custom save
+                </button>
+                <button type="button" className="btn btn-secondary" onClick={() => resetForm()}>
+                  Custom reset
+                </button>
+              </div>
+            )
+          : undefined
+      }
     >
       <h5>Form configuration:</h5>
       <FormGroupSwitch
@@ -151,6 +166,12 @@ export function FormExamples() {
         name="changeVariableCustomValidation"
         label="Change validation for variable custom validation?"
         afterChange={(value) => setChangeCustomValidation(value)}
+      />
+      <FormGroupSwitch
+        id="useCustomActions"
+        name="useCustomActions"
+        label="Use form custom actions?"
+        afterChange={(value) => setUseCustomActions(value)}
       />
       <hr />
       <div className="row">
@@ -734,9 +755,27 @@ export function FormExamples() {
         includeEmptyItem={false}
         menuClassName="p-4 w-100"
       />
+
+      <ResetForm />
     </Form>
   );
 }
+
+const ResetForm = () => {
+  const formControl = useFormControl();
+
+  const reset = () => {
+    console.log('reset form');
+
+    formControl.resetFormData();
+  };
+
+  return (
+    <button type="button" className="btn btn-outline-secondary mb-3" onClick={reset}>
+      Reset form
+    </button>
+  );
+};
 
 const FormSwitchExample = () => {
   const autocompleteField1FormControl = useFormControl('autocompleteField1');

--- a/src/forms/Form.jsx
+++ b/src/forms/Form.jsx
@@ -76,7 +76,7 @@ export function Form({
     <form {...formProps}>
       <FormContext.Provider value={formState}>{children}</FormContext.Provider>
 
-      <FormActions {...{ submitLabel, cancelLabel, onCancel: handleCancel, isSubmiting, customActions }} />
+      <FormActions {...{ submitLabel, cancelLabel, onCancel: handleCancel, isSubmiting, customActions, resetForm }} />
     </form>
   );
 }

--- a/src/forms/Form.jsx
+++ b/src/forms/Form.jsx
@@ -92,7 +92,7 @@ Form.defaultProps = {
 Form.propTypes = {
   cancelLabel: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
-  customActions: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   customValidation: PropTypes.bool,
   initialValues: PropTypes.object,
   onCancel: PropTypes.func,

--- a/src/forms/FormActions.jsx
+++ b/src/forms/FormActions.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isFunction } from 'js-var-type';
 
-export function FormActions({ submitLabel, cancelLabel, onCancel, isSubmiting, customActions }) {
+export function FormActions({ submitLabel, cancelLabel, onCancel, isSubmiting, customActions, resetForm }) {
   if (customActions) {
-    return isFunction(customActions) ? customActions(isSubmiting) : customActions;
+    return isFunction(customActions) ? customActions(isSubmiting, { onCancel, resetForm }) : customActions;
   }
 
   return (
@@ -25,4 +25,5 @@ FormActions.propTypes = {
   onCancel: PropTypes.func.isRequired,
   isSubmiting: PropTypes.bool,
   customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  resetForm: PropTypes.func,
 };

--- a/src/forms/FormActions.jsx
+++ b/src/forms/FormActions.jsx
@@ -24,6 +24,6 @@ FormActions.propTypes = {
   cancelLabel: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   onCancel: PropTypes.func.isRequired,
   isSubmiting: PropTypes.bool,
-  customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   resetForm: PropTypes.func,
 };

--- a/src/forms/helpers/useFormControl.js
+++ b/src/forms/helpers/useFormControl.js
@@ -48,6 +48,7 @@ export function useFormControl(name, type) {
     handleOnChange,
     register,
     getFormData: () => formState.getFormData(),
+    resetFormData: () => formState.reset(),
     isValid: () => formState.getValidationMessage(name) === '',
     getFormSubmitedAttempted: () => formState.getSubmitedAttempted(),
   };


### PR DESCRIPTION
PR para exportar função de reset do form. Pretendo usar essa opção para ter um botão genérico para limpar formulários. Exemplo (implementação para 381)
<img width="705" height="914" alt="image" src="https://github.com/user-attachments/assets/10b3d95d-55f2-4e1e-80be-61ff72c50b25" />

Importante: esse PR só exporta as funções de reset já implementadas e o uso dela no Geolabor, no momento, acredito que será restrito. Por exemplo: vi que ao resetar o form, o onChange e transform não são trigados. Pode ser que seja necessário alterar a função exportada para uso ou incrementar sua lógica no futuro. Mas por enquanto, achei melhor a demanda aparecer primeiro para termos um exemplo de uso como base.