### PR TITLE
feat: exporta função de clear Form

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -21,6 +21,7 @@ export function FormExamples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   const [changeCustomValidation, setChangeCustomValidation] = useState(false);
   const [useCustomActions, setUseCustomActions] = useState(false);
+  console.log('🚀 ~ FormExamples ~ useCustomActions:', useCustomActions);
 
   const validations = useMemo(
     () => ({

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -20,6 +20,7 @@ import {
 export function FormExamples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   const [changeCustomValidation, setChangeCustomValidation] = useState(false);
+  const [useCustomActions, setUseCustomActions] = useState(false);
 
   const validations = useMemo(
     () => ({
@@ -138,6 +139,20 @@ export function FormExamples() {
       }}
       customValidation={bootstrapFormValidation}
       validations={validations}
+      customActions={
+        useCustomActions
+          ? (isSubmiting, { onCancel, resetForm }) => (
+              <div>
+                <button type="submit" className="btn btn-success">
+                  Custom save
+                </button>
+                <button type="button" className="btn btn-secondary" onClick={() => resetForm()}>
+                  Custom reset
+                </button>
+              </div>
+            )
+          : undefined
+      }
     >
       <h5>Form configuration:</h5>
       <FormGroupSwitch
@@ -151,6 +166,12 @@ export function FormExamples() {
         name="changeVariableCustomValidation"
         label="Change validation for variable custom validation?"
         afterChange={(value) => setChangeCustomValidation(value)}
+      />
+      <FormGroupSwitch
+        id="useCustomActions"
+        name="useCustomActions"
+        label="Use form custom actions?"
+        afterChange={(value) => setUseCustomActions(value)}
       />
       <hr />
       <div className="row">
@@ -734,9 +755,27 @@ export function FormExamples() {
         includeEmptyItem={false}
         menuClassName="p-4 w-100"
       />
+
+      <ResetForm />
     </Form>
   );
 }
+
+const ResetForm = () => {
+  const formControl = useFormControl();
+
+  const reset = () => {
+    console.log('reset form');
+
+    formControl.resetFormData();
+  };
+
+  return (
+    <button type="button" className="btn btn-outline-secondary mb-3" onClick={reset}>
+      Reset form
+    </button>
+  );
+};
 
 const FormSwitchExample = () => {
   const autocompleteField1FormControl = useFormControl('autocompleteField1');

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -21,7 +21,6 @@ export function FormExamples() {
   const [bootstrapFormValidation, setBootstrapFormValidation] = useState(false);
   const [changeCustomValidation, setChangeCustomValidation] = useState(false);
   const [useCustomActions, setUseCustomActions] = useState(false);
-  console.log('🚀 ~ FormExamples ~ useCustomActions:', useCustomActions);
 
   const validations = useMemo(
     () => ({

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -129,6 +129,8 @@ export function FormExamples() {
         });
       }}
       transform={(formData, _, update) => {
+        console.log('transform >> formData:', formData);
+
         formData.__v = formData.__v ? formData.__v + 1 : 1;
 
         update(formData);
@@ -141,13 +143,16 @@ export function FormExamples() {
       validations={validations}
       customActions={
         useCustomActions
-          ? (isSubmiting, { onCancel, resetForm }) => (
+          ? (isSubmiting, { onCancel, resetForm, clearForm }) => (
               <div>
-                <button type="submit" className="btn btn-success">
+                <button type="submit" className="btn btn-success me-2">
                   Custom save
                 </button>
-                <button type="button" className="btn btn-secondary" onClick={() => resetForm()}>
+                <button type="button" className="btn btn-secondary me-2" onClick={() => resetForm()}>
                   Custom reset
+                </button>
+                <button type="button" className="btn btn-info" onClick={() => clearForm()}>
+                  Custom clear
                 </button>
               </div>
             )
@@ -757,6 +762,7 @@ export function FormExamples() {
       />
 
       <ResetForm />
+      <ClearForm />
     </Form>
   );
 }
@@ -765,7 +771,7 @@ const ResetForm = () => {
   const formControl = useFormControl();
 
   const reset = () => {
-    console.log('reset form');
+    console.log('reset form - resets to initial state');
 
     formControl.resetFormData();
   };
@@ -773,6 +779,22 @@ const ResetForm = () => {
   return (
     <button type="button" className="btn btn-outline-secondary mb-3" onClick={reset}>
       Reset form
+    </button>
+  );
+};
+
+const ClearForm = () => {
+  const formControl = useFormControl();
+
+  const clear = () => {
+    console.log('clear form - sets empty state');
+
+    formControl.clearFormData();
+  };
+
+  return (
+    <button type="button" className="btn btn-outline-info ms-2 mb-3" onClick={clear}>
+      Clear form
     </button>
   );
 };

--- a/src/forms/Form.jsx
+++ b/src/forms/Form.jsx
@@ -22,12 +22,21 @@ export function Form({
   const formRef = useRef(null);
   const [isSubmiting, setIsSubmiting] = useState(false);
 
+  /* Resets to initial values/state */
   function resetForm() {
     if (formRef.current && formRef.current.classList) {
       formRef.current.classList.remove('was-validated');
     }
 
     formState.reset();
+  }
+
+  function clearForm() {
+    if (formRef.current && formRef.current.classList) {
+      formRef.current.classList.remove('was-validated');
+    }
+
+    formState.clear();
   }
 
   function handleSubmit(e) {
@@ -76,7 +85,17 @@ export function Form({
     <form {...formProps}>
       <FormContext.Provider value={formState}>{children}</FormContext.Provider>
 
-      <FormActions {...{ submitLabel, cancelLabel, onCancel: handleCancel, isSubmiting, customActions, resetForm }} />
+      <FormActions
+        {...{
+          submitLabel,
+          cancelLabel,
+          onCancel: handleCancel,
+          isSubmiting,
+          customActions,
+          resetForm,
+          clearForm,
+        }}
+      />
     </form>
   );
 }

--- a/src/forms/Form.jsx
+++ b/src/forms/Form.jsx
@@ -76,7 +76,7 @@ export function Form({
     <form {...formProps}>
       <FormContext.Provider value={formState}>{children}</FormContext.Provider>
 
-      <FormActions {...{ submitLabel, cancelLabel, onCancel: handleCancel, isSubmiting, customActions }} />
+      <FormActions {...{ submitLabel, cancelLabel, onCancel: handleCancel, isSubmiting, customActions, resetForm }} />
     </form>
   );
 }

--- a/src/forms/Form.jsx
+++ b/src/forms/Form.jsx
@@ -92,7 +92,7 @@ Form.defaultProps = {
 Form.propTypes = {
   cancelLabel: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
-  customActions: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   customValidation: PropTypes.bool,
   initialValues: PropTypes.object,
   onCancel: PropTypes.func,

--- a/src/forms/FormActions.jsx
+++ b/src/forms/FormActions.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isFunction } from 'js-var-type';
 
-export function FormActions({ submitLabel, cancelLabel, onCancel, isSubmiting, customActions }) {
+export function FormActions({ submitLabel, cancelLabel, onCancel, isSubmiting, customActions, resetForm }) {
   if (customActions) {
-    return isFunction(customActions) ? customActions(isSubmiting) : customActions;
+    return isFunction(customActions) ? customActions(isSubmiting, { onCancel, resetForm }) : customActions;
   }
 
   return (
@@ -25,4 +25,5 @@ FormActions.propTypes = {
   onCancel: PropTypes.func.isRequired,
   isSubmiting: PropTypes.bool,
   customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  resetForm: PropTypes.func,
 };

--- a/src/forms/FormActions.jsx
+++ b/src/forms/FormActions.jsx
@@ -24,6 +24,6 @@ FormActions.propTypes = {
   cancelLabel: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   onCancel: PropTypes.func.isRequired,
   isSubmiting: PropTypes.bool,
-  customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   resetForm: PropTypes.func,
 };

--- a/src/forms/FormActions.jsx
+++ b/src/forms/FormActions.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isFunction } from 'js-var-type';
 
-export function FormActions({ submitLabel, cancelLabel, onCancel, isSubmiting, customActions, resetForm }) {
+export function FormActions({ submitLabel, cancelLabel, clearForm, onCancel, isSubmiting, customActions, resetForm }) {
   if (customActions) {
-    return isFunction(customActions) ? customActions(isSubmiting, { onCancel, resetForm }) : customActions;
+    return isFunction(customActions) ? customActions(isSubmiting, { clearForm, onCancel, resetForm }) : customActions;
   }
 
   return (
@@ -22,6 +22,7 @@ export function FormActions({ submitLabel, cancelLabel, onCancel, isSubmiting, c
 FormActions.propTypes = {
   submitLabel: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   cancelLabel: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  clearForm: PropTypes.func,
   onCancel: PropTypes.func.isRequired,
   isSubmiting: PropTypes.bool,
   customActions: PropTypes.oneOfType([PropTypes.func, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),

--- a/src/forms/helpers/useForm.js
+++ b/src/forms/helpers/useForm.js
@@ -44,15 +44,30 @@ function useFormState(initialState, { onChange, transform }) {
         return nextFormState;
       });
     },
+    /* Resets to initial values/state */
     resetState() {
       setIsDirty(false);
       setFormState(initialState);
+    },
+    /* Sets empty state */
+    clearState() {
+      setIsDirty(true);
+
+      setFormState(() => {
+        const nextFormState = {};
+
+        setTimeout(() => {
+          transformRef.current(nextFormState);
+        });
+
+        return nextFormState;
+      });
     },
   };
 }
 
 export function useForm(initialState, { validations, onChange, transform }) {
-  const { getState, updateState, resetState } = useFormState(initialState, { onChange, transform });
+  const { getState, updateState, resetState, clearState } = useFormState(initialState, { onChange, transform });
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [, setRefreshForm] = useState(false);
   const { getAllKeys: getElementNames, get: getElementRefs, push: registerElementRef } = useArrayValueMap();
@@ -124,6 +139,9 @@ export function useForm(initialState, { validations, onChange, transform }) {
     },
     getValue(name) {
       return getValueByPath(formState, name);
+    },
+    clear() {
+      clearState();
     },
     reset() {
       resetState();

--- a/src/forms/helpers/useFormControl.js
+++ b/src/forms/helpers/useFormControl.js
@@ -48,6 +48,7 @@ export function useFormControl(name, type) {
     handleOnChange,
     register,
     getFormData: () => formState.getFormData(),
+    resetFormData: () => formState.reset(),
     isValid: () => formState.getValidationMessage(name) === '',
     getFormSubmitedAttempted: () => formState.getSubmitedAttempted(),
   };

--- a/src/forms/helpers/useFormControl.js
+++ b/src/forms/helpers/useFormControl.js
@@ -48,7 +48,8 @@ export function useFormControl(name, type) {
     handleOnChange,
     register,
     getFormData: () => formState.getFormData(),
-    resetFormData: () => formState.reset(),
+    resetFormData: () => formState.reset(), /* Resets to initial values/state */
+    clearFormData: () => formState.clear(), /* Sets empty state */
     isValid: () => formState.getValidationMessage(name) === '',
     getFormSubmitedAttempted: () => formState.getSubmitedAttempted(),
   };


### PR DESCRIPTION
No PR https://github.com/geolaborapp/react-bootstrap-utils/pull/79 implementei a exportação do resetForm. Essa implementação basicamente disponibilizou a lógica já existente de resetState.
Conscientemente no PR 79, vi que a lógica de resetState resetava o formulário para estado inicial. Vi que não era equivalente a um "update geral" para state vazio. Por mais que eu tivesse consciência desse comportamento, eu não percebi que ele não era exatamente o que eu precisava para https://github.com/geolaborapp/geolabor/pull/9157. Isso porque o estado inicial de um filtro com "persist filter" não é vazio. Ou seja, ao resetar para estado inicial do form do filtro, algum campo viria preenchido (caso o último filtro persistido fosse diferente de vazio).

Nesse PR, estou implementando a lógica do clear form. Ele deve funcionar como um update para state vazio, ou seja, ao clear form, o onChange e transform são disparados.