### PR TITLE
fix: corrige valor do input de datetime-local ao resetform ou clearForm

### DIFF
--- a/src/forms/FormInput.jsx
+++ b/src/forms/FormInput.jsx
@@ -27,13 +27,8 @@ export function FormInput({
     name,
     required,
     type,
+    value: getValue(),
   };
-
-  if (type === 'datetime-local') {
-    attrs.defaultValue = getValue();
-  } else {
-    attrs.value = getValue();
-  }
 
   return (
     <input


### PR DESCRIPTION
Ao fazer o clear ou reset do form, o texto do input de data não sai da tela. O valor não está no state, o valor não está na DOM.
<img width="1725" height="488" alt="image" src="https://github.com/user-attachments/assets/00c4466d-0b0d-4493-a136-ad5380050a1f" />

olhando o código, há 5 anos tem esse commit:
<img width="1367" height="443" alt="image" src="https://github.com/user-attachments/assets/9598515e-9c1b-4ada-8f8b-d4dd707b7c7d" />

Não sei porque precisou da tratativa específica para datetime-local. (lições sobre como alguns comentários no código podem ser úteis :eyes: ). Estou com medo de tirar. Mas acho que o jeito será fazer esse fix, testar todos os pontos do geolabor usando datetime-local e torcer para nesse processo encontrar o ponto que justificou colocar esse if. Se não der problema nenhum, seria bom também, mas eu ia ficar achando que tinha um problema sim, mas que a gente não achou.