### PR TITLE
feat: Adiciona FormTable, FormGroupTable,  UncontrolledFormTable e UncontrolledFormGroupTable

### DIFF
--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -898,7 +898,7 @@ function FormGroupTable1() {
           },
         ],
       }}
-      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getRemoveComponent={(removeItem) => <i className="bi bi-trash-fill" onClick={() => removeItem()}></i>}
       getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
     />
   );
@@ -922,7 +922,7 @@ function FormGroupTable2() {
           },
         ],
       }}
-      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getRemoveComponent={(removeItem) => <i className="bi bi-trash-fill" onClick={() => removeItem()}></i>}
       getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
     />
   );

--- a/demo/FormExamples.jsx
+++ b/demo/FormExamples.jsx
@@ -14,6 +14,8 @@ import {
   FormGroupAutocompleteTag,
   Table,
   FormAutocompleteTag,
+  FormGroupTable,
+  Dialog,
   // eslint-disable-next-line import/no-unresolved
 } from '../dist/main';
 
@@ -92,6 +94,14 @@ export function FormExamples() {
         {
           validate(value) {
             return value;
+          },
+        },
+      ],
+      formTable2: [
+        {
+          message: 'Must have more than 2 itens',
+          validate(value) {
+            return value?.length > 2;
           },
         },
       ],
@@ -761,6 +771,12 @@ export function FormExamples() {
         menuClassName="p-4 w-100"
       />
 
+      <h5>FormTable</h5>
+      <div className="row mb-2">
+        <FormGroupTable1 />
+        <FormGroupTable2 />
+      </div>
+
       <ResetForm />
       <ClearForm />
     </Form>
@@ -859,5 +875,84 @@ function FormAutocompleteTagsWithCustomLabel() {
         />
       </div>
     </div>
+  );
+}
+
+function FormGroupTable1() {
+  return (
+    <FormGroupTable
+      name="formTable1"
+      required
+      label="Simple FormTable"
+      afterChange={(...args) => console.log('formTable', args)}
+      tableProps={{
+        actionLabel: 'Actions',
+        columns: [
+          {
+            attribute: 'name',
+            label: 'Name',
+          },
+          {
+            attribute: 'number',
+            label: 'Number',
+          },
+        ],
+      }}
+      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
+    />
+  );
+}
+function FormGroupTable2() {
+  return (
+    <FormGroupTable
+      name="formTable2"
+      required
+      label="FormTable with minimum itens validation"
+      tableProps={{
+        actionLabel: 'Actions',
+        columns: [
+          {
+            attribute: 'name',
+            label: 'Name',
+          },
+          {
+            attribute: 'number',
+            label: 'Number',
+          },
+        ],
+      }}
+      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
+    />
+  );
+}
+
+function AddFormGroupTableItem({ addItem }) {
+  return (
+    <Dialog
+      title="Add item"
+      body={({ close }) => (
+        <Form
+          initialValues={{}}
+          onSubmit={(data) => {
+            console.info('submit', data);
+            addItem(data);
+            close();
+          }}
+          onCancel={() => {
+            console.warn('cancel');
+            close();
+          }}
+        >
+          <FormGroupInput name="name" label="Name" required />
+          <FormGroupInput name="number" label="Number" type="number" required />
+        </Form>
+      )}
+    >
+      <button type="button" className="btn btn-primary">
+        Add item
+      </button>
+    </Dialog>
   );
 }

--- a/demo/UncontrolledFormExamples.jsx
+++ b/demo/UncontrolledFormExamples.jsx
@@ -14,6 +14,8 @@ import {
   UncontrolledFormGroupAutocomplete,
   UncontrolledFormGroupDropdown,
   UncontrolledFormGroupRadio,
+  UncontrolledFormGroupTable,
+  Dialog,
 } from '../dist/main';
 
 export function UncontrolledFormExamples() {
@@ -81,6 +83,14 @@ export function UncontrolledFormExamples() {
               message: 'Must be filled if AttrA is not empty',
               validate(value, formData) {
                 return !formData.attrA || value;
+              },
+            },
+          ],
+          formTable2: [
+            {
+              message: 'Must have more than 2 itens',
+              validate(value) {
+                return value?.length > 2;
               },
             },
           ],
@@ -425,6 +435,12 @@ export function UncontrolledFormExamples() {
         <div className="row mb-2">
           <FormTextareaSetValueTeste1 />
           <FormTextareaSetValueTeste2 />
+        </div>
+
+        <h5>FormTable</h5>
+        <div className="row mb-2">
+          <FormUncontrolledFormGroupTable1 />
+          <FormUncontrolledFormGroupTable2 />
         </div>
       </UncontrolledForm>
     </div>
@@ -1093,5 +1109,84 @@ function FormTextareaSetValueTeste2({}) {
         rows="5"
       />
     </div>
+  );
+}
+
+function FormUncontrolledFormGroupTable1() {
+  return (
+    <UncontrolledFormGroupTable
+      name="formTable1"
+      required
+      label="Simple UncontrolledFormTable"
+      afterChange={(...args) => console.log('formTable', args)}
+      tableProps={{
+        actionLabel: 'Actions',
+        columns: [
+          {
+            attribute: 'name',
+            label: 'Name',
+          },
+          {
+            attribute: 'number',
+            label: 'Number',
+          },
+        ],
+      }}
+      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
+    />
+  );
+}
+function FormUncontrolledFormGroupTable2() {
+  return (
+    <UncontrolledFormGroupTable
+      name="formTable2"
+      required
+      label="UncontrolledFormTable with minimum itens validation"
+      tableProps={{
+        actionLabel: 'Actions',
+        columns: [
+          {
+            attribute: 'name',
+            label: 'Name',
+          },
+          {
+            attribute: 'number',
+            label: 'Number',
+          },
+        ],
+      }}
+      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
+    />
+  );
+}
+
+function AddFormGroupTableItem({ addItem }) {
+  return (
+    <Dialog
+      title="Add item"
+      body={({ close }) => (
+        <UncontrolledForm
+          initialValues={{}}
+          onSubmit={(data) => {
+            console.info('submit', data);
+            addItem(data);
+            close();
+          }}
+          onCancel={() => {
+            console.warn('cancel');
+            close();
+          }}
+        >
+          <UncontrolledFormGroupInput name="name" label="Name" required />
+          <UncontrolledFormGroupInput name="number" label="Number" type="number" required />
+        </UncontrolledForm>
+      )}
+    >
+      <button type="button" className="btn btn-primary">
+        Add item
+      </button>
+    </Dialog>
   );
 }

--- a/demo/UncontrolledFormExamples.jsx
+++ b/demo/UncontrolledFormExamples.jsx
@@ -1132,7 +1132,7 @@ function FormUncontrolledFormGroupTable1() {
           },
         ],
       }}
-      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getRemoveComponent={(removeItem) => <i className="bi bi-trash-fill" onClick={() => removeItem()}></i>}
       getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
     />
   );
@@ -1156,7 +1156,7 @@ function FormUncontrolledFormGroupTable2() {
           },
         ],
       }}
-      getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+      getRemoveComponent={(removeItem) => <i className="bi bi-trash-fill" onClick={() => removeItem()}></i>}
       getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
     />
   );

--- a/src/forms/FormTable.jsx
+++ b/src/forms/FormTable.jsx
@@ -50,7 +50,7 @@ import { FormGroup } from './FormGroup';
  *         },
  *       ],
  *     }}
- *     getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+ *     getRemoveComponent={(removeItem) => <i className="bi bi-trash-fill" onClick={() => removeItem()}></i>}
  *     getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
  *   />
  * );

--- a/src/forms/FormTable.jsx
+++ b/src/forms/FormTable.jsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+import { isFunction } from 'js-var-type';
+
+import { formatClasses } from '../utils/attributes';
+
+import { Table } from '../table/Table';
+
+import { useFormControl } from './helpers/useFormControl';
+import { booleanOrFunction } from './helpers/form-helpers';
+import { FormGroup } from './FormGroup';
+
+/**
+ * FormTable
+ *
+ * This component allows you to control an array of itens in an Form.
+ * This array will be shown as a table.
+ * @param {object} param0
+ * @param {name} param0.name - Name of the field
+ * @param {boolean|Function=} param0.required - Defines whether the field is required for the form or not. If it's a function, the first parameter is the formData
+ * @param {boolean|Function=} param0.disabled - Defines whether the field is disabled for the form or not. If it's a function, the first parameter is the formData
+ * @param {Function=} param0.afterChange - Function that will run after an update on the field
+ * @param {object} param0.tableProps - Props of the "Table" component
+ * @param {Function=} param0.getCustomActions -  Function that recieves "item" and "index", and must return an array of Table actions.
+ * @param {Function} param0.getAddItemComponent - Function that recieves the "item to be added" and must return the element that will be used to add new itens on the Table
+ * @param {Function} param0.getRemoveComponent - Function that recieves the "remove item function" and must return the element that will be used to remove the item
+ * @returns {JSX.Element}
+ *
+ * @example
+ *
+ * ```jsx
+ * function FormUncontrolledFormGroupTable() {
+ * return (
+ *   <FormGroupTable
+ *     name="formTable"
+ *     required
+ *     label="Simple FormTable"
+ *     afterChange={(...args) => console.log('formTable', args)}
+ *     tableProps={{
+ *       actionLabel: 'Actions',
+ *       columns: [
+ *         {
+ *           attribute: 'name',
+ *           label: 'Name',
+ *         },
+ *         {
+ *           attribute: 'number',
+ *           label: 'Number',
+ *         },
+ *       ],
+ *     }}
+ *     getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+ *     getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
+ *   />
+ * );
+ *}
+ *
+ *function AddFormGroupTableItem({ addItem }) {
+ * // Form to generate new itens
+ *
+ *  return (
+ *    <Dialog
+ *      title="Add item"
+ *      body={({ close }) => (
+ *        <Form
+ *          initialValues={{}}
+ *          onSubmit={(data) => {
+ *            addItem(data);
+ *            close();
+ *          }}
+ *          onCancel={() => {
+ *            close();
+ *          }}
+ *        >
+ *          <FormGroupInput name="name" label="Name" required />
+ *          <FormGroupInput name="number" label="Number" type="number" required />
+ *        </Form>
+ *      )}
+ *    >
+ *      <button type="button" className="btn btn-primary">
+ *        Add item
+ *      </button>
+ *    </Dialog>
+ *  );
+ *}
+ * ```
+ */
+
+export function FormTable({
+  name,
+  required: _required,
+  disabled: _disabled,
+  afterChange,
+  tableProps,
+  getCustomActions,
+  getAddItemComponent,
+  getRemoveComponent,
+  ..._attrs
+}) {
+  const { getValue, register, getFormData, setValue } = useFormControl(name, 'array');
+  const registerRef = useCallback(register, [register]);
+  const disabled = booleanOrFunction(_disabled, getFormData());
+  const required = booleanOrFunction(_required, getFormData());
+
+  const value = useMemo(() => getValue() || [], [getValue]);
+
+  const removeItem = useCallback(
+    (doc, index) => {
+      const newValue = value?.filter?.((_, i) => i !== index) ?? [];
+
+      setValue(newValue);
+
+      if (isFunction(afterChange)) {
+        afterChange(newValue);
+      }
+    },
+    [afterChange, setValue, value]
+  );
+  const addItem = useCallback(
+    (item) => {
+      const newValue = [...(value || []), item];
+
+      setValue(newValue);
+
+      if (isFunction(afterChange)) {
+        afterChange(newValue);
+      }
+    },
+    [afterChange, setValue, value]
+  );
+
+  const addItemComponent = useMemo(() => getAddItemComponent?.(addItem) ?? <></>, [addItem, getAddItemComponent]);
+
+  const attrs = {
+    ..._attrs,
+    disabled,
+    name,
+    required,
+  };
+
+  return (
+    <>
+      <input
+        className={formatClasses(['form-control', 'visually-hidden'])}
+        {...attrs}
+        ref={registerRef}
+        id={name}
+        value={value?.length > 0 ? '1' : ''} //for required validation
+      />
+      {addItemComponent}
+      <Table
+        actions={(doc, index) => [
+          ...(getCustomActions?.(doc, index) ?? []),
+          {
+            content: getRemoveComponent(() => removeItem(doc, index)),
+          },
+        ]}
+        docs={value}
+        {...tableProps}
+      ></Table>
+    </>
+  );
+}
+
+FormTable.defaultProps = {
+  tableProps: {},
+};
+
+const formTableProps = {
+  afterChange: PropTypes.func,
+  disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  name: PropTypes.string.isRequired,
+  required: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  tableProps: PropTypes.shape(Table.propTypes),
+  getCustomActions: PropTypes.func,
+  getRemoveComponent: PropTypes.func,
+  getAddItemComponent: PropTypes.func,
+};
+
+FormTable.propTypes = formTableProps;
+
+export function FormGroupTable(props) {
+  return (
+    <FormGroup {...props} id={props?.name}>
+      <FormTable {...props} />
+    </FormGroup>
+  );
+}
+
+FormGroupTable.propTypes = {
+  ...formTableProps,
+  help: PropTypes.node,
+  label: PropTypes.node.isRequired,
+};

--- a/src/forms/FormTable.jsx
+++ b/src/forms/FormTable.jsx
@@ -96,7 +96,6 @@ export function FormTable({
   getCustomActions,
   getAddItemComponent,
   getRemoveComponent,
-  ..._attrs
 }) {
   const { getValue, register, getFormData, setValue } = useFormControl(name, 'array');
   const registerRef = useCallback(register, [register]);
@@ -133,7 +132,6 @@ export function FormTable({
   const addItemComponent = useMemo(() => getAddItemComponent?.(addItem) ?? <></>, [addItem, getAddItemComponent]);
 
   const attrs = {
-    ..._attrs,
     disabled,
     name,
     required,

--- a/src/forms/index.js
+++ b/src/forms/index.js
@@ -9,6 +9,7 @@ export * from './FormInput';
 export * from './FormRadio';
 export * from './FormSelect';
 export * from './FormSwitch';
+export * from './FormTable';
 export * from './FormTextarea';
 export * from './helpers/useFormControl';
 export * from './helpers/useFormData';

--- a/src/uncontrolled-forms/UncontrolledFormTable.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormTable.jsx
@@ -1,0 +1,209 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { isFunction } from 'js-var-type';
+
+import { Table } from '../table/Table';
+import { formatClasses } from '../utils/attributes';
+
+import { booleanOrFunction } from './helpers/form-helpers';
+
+import { useUncontrolledFormControl } from './helpers/useUncontrolledFormControl';
+import { UncontrolledFormGroup } from './UncontrolledFormGroup';
+
+/**
+ * UncontrolledFormTable
+ *
+ * This component allows you to control an array of itens in an UncontrolledForm.
+ * This array will be shown as a table.
+ * @param {object} param0
+ * @param {name} param0.name - Name of the field
+ * @param {boolean|Function=} param0.required - Defines whether the field is required for the form or not. If it's a function, the first parameter is the formData
+ * @param {boolean|Function=} param0.disabled - Defines whether the field is disabled for the form or not. If it's a function, the first parameter is the formData
+ * @param {Function=} param0.afterChange - Function that will run after an update on the field
+ * @param {object} param0.tableProps - Props of the "Table" component
+ * @param {Function=} param0.getCustomActions -  Function that recieves "item" and "index", and must return an array of Table actions.
+ * @param {Function} param0.getAddItemComponent - Function that recieves the "item to be added" and must return the element that will be used to add new itens on the Table
+ * @param {Function} param0.getRemoveComponent - Function that recieves the "remove item function" and must return the element that will be used to remove the item
+ * @returns {JSX.Element}
+ *
+ * @example
+ *
+ * ```jsx
+ * function FormUncontrolledFormGroupTable() {
+ * return (
+ *   <UncontrolledFormGroupTable
+ *     name="formTable"
+ *     required
+ *     label="Simple UncontrolledFormTable"
+ *     afterChange={(...args) => console.log('formTable', args)}
+ *     tableProps={{
+ *       actionLabel: 'Actions',
+ *       columns: [
+ *         {
+ *           attribute: 'name',
+ *           label: 'Name',
+ *         },
+ *         {
+ *           attribute: 'number',
+ *           label: 'Number',
+ *         },
+ *       ],
+ *     }}
+ *     getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+ *     getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
+ *   />
+ * );
+ *}
+ *
+ *function AddFormGroupTableItem({ addItem }) {
+ * // Form to generate new itens
+ *
+ *  return (
+ *    <Dialog
+ *      title="Add item"
+ *      body={({ close }) => (
+ *        <UncontrolledForm
+ *          initialValues={{}}
+ *          onSubmit={(data) => {
+ *            addItem(data);
+ *            close();
+ *          }}
+ *          onCancel={() => {
+ *            close();
+ *          }}
+ *        >
+ *          <UncontrolledFormGroupInput name="name" label="Name" required />
+ *          <UncontrolledFormGroupInput name="number" label="Number" type="number" required />
+ *        </UncontrolledForm>
+ *      )}
+ *    >
+ *      <button type="button" className="btn btn-primary">
+ *        Add item
+ *      </button>
+ *    </Dialog>
+ *  );
+ *}
+ * ```
+ */
+
+export function UncontrolledFormTable({
+  name,
+  required: _required,
+  disabled: _disabled,
+  afterChange,
+  tableProps,
+  getCustomActions,
+  getAddItemComponent,
+  getRemoveComponent,
+  ..._attrs
+}) {
+  const state = useState([]);
+
+  const { getValue, getFormData, registerInputRef, setValue } = useUncontrolledFormControl(name, 'array', {
+    state,
+  });
+
+  const value = useMemo(() => getValue(), [getValue]);
+
+  const removeItem = useCallback(
+    (doc, index) => {
+      let newValue;
+
+      setValue((prevState) => {
+        newValue = prevState?.filter?.((_, i) => i !== index) ?? [];
+
+        return newValue;
+      });
+
+      if (isFunction(afterChange)) {
+        afterChange(newValue);
+      }
+    },
+    [afterChange, setValue]
+  );
+  const addItem = useCallback(
+    (item) => {
+      let newValue;
+
+      setValue((prevState) => {
+        newValue = [...(prevState || []), item];
+
+        return newValue;
+      });
+
+      if (isFunction(afterChange)) {
+        afterChange(newValue);
+      }
+    },
+    [afterChange, setValue]
+  );
+
+  const addItemComponent = useMemo(() => getAddItemComponent?.(addItem) ?? <></>, [addItem, getAddItemComponent]);
+
+  const disabled = booleanOrFunction(_disabled, getFormData());
+  const required = booleanOrFunction(_required, getFormData());
+
+  const attrs = {
+    ..._attrs,
+    disabled,
+    name,
+    required,
+  };
+
+  /** The input is for the default form validation, and will not be shown */
+
+  return (
+    <>
+      <input
+        className={formatClasses(['form-control', 'visually-hidden'])}
+        {...attrs}
+        ref={registerInputRef}
+        id={name}
+        value={value?.length > 0 ? '1' : ''} //for required validation
+      />
+      {addItemComponent}
+      <Table
+        actions={(doc, index) => [
+          ...(getCustomActions?.(doc, index) ?? []),
+          {
+            content: getRemoveComponent(() => removeItem(doc, index)),
+          },
+        ]}
+        docs={value}
+        {...tableProps}
+      ></Table>
+    </>
+  );
+}
+
+UncontrolledFormTable.defaultProps = {
+  tableProps: {},
+};
+
+const formTableProps = {
+  afterChange: PropTypes.func,
+  disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  name: PropTypes.string.isRequired,
+  required: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+  tableProps: PropTypes.shape(Table.propTypes),
+  getCustomActions: PropTypes.func,
+  getRemoveComponent: PropTypes.func,
+  getAddItemComponent: PropTypes.func,
+};
+
+UncontrolledFormTable.propTypes = formTableProps;
+
+export function UncontrolledFormGroupTable(props) {
+  return (
+    <UncontrolledFormGroup {...props} id={props?.name}>
+      <UncontrolledFormTable {...props} />
+    </UncontrolledFormGroup>
+  );
+}
+
+UncontrolledFormGroupTable.propTypes = {
+  ...formTableProps,
+  help: PropTypes.node,
+  label: PropTypes.node.isRequired,
+};

--- a/src/uncontrolled-forms/UncontrolledFormTable.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormTable.jsx
@@ -96,7 +96,6 @@ export function UncontrolledFormTable({
   getCustomActions,
   getAddItemComponent,
   getRemoveComponent,
-  ..._attrs
 }) {
   const state = useState([]);
 
@@ -145,7 +144,6 @@ export function UncontrolledFormTable({
   const required = booleanOrFunction(_required, getFormData());
 
   const attrs = {
-    ..._attrs,
     disabled,
     name,
     required,

--- a/src/uncontrolled-forms/UncontrolledFormTable.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormTable.jsx
@@ -50,7 +50,7 @@ import { UncontrolledFormGroup } from './UncontrolledFormGroup';
  *         },
  *       ],
  *     }}
- *     getRemoveComponent={(removeItem) => <i class="bi bi-trash-fill" onClick={() => removeItem()}></i>}
+ *     getRemoveComponent={(removeItem) => <i className="bi bi-trash-fill" onClick={() => removeItem()}></i>}
  *     getAddItemComponent={(addItem) => <AddFormGroupTableItem addItem={addItem} />}
  *   />
  * );
@@ -107,35 +107,27 @@ export function UncontrolledFormTable({
 
   const removeItem = useCallback(
     (doc, index) => {
-      let newValue;
+      const newValue = value?.filter?.((_, i) => i !== index) ?? [];
 
-      setValue((prevState) => {
-        newValue = prevState?.filter?.((_, i) => i !== index) ?? [];
-
-        return newValue;
-      });
+      setValue(newValue);
 
       if (isFunction(afterChange)) {
         afterChange(newValue);
       }
     },
-    [afterChange, setValue]
+    [afterChange, setValue, value]
   );
   const addItem = useCallback(
     (item) => {
-      let newValue;
+      const newValue = [...(value || []), item];
 
-      setValue((prevState) => {
-        newValue = [...(prevState || []), item];
-
-        return newValue;
-      });
+      setValue(newValue);
 
       if (isFunction(afterChange)) {
         afterChange(newValue);
       }
     },
-    [afterChange, setValue]
+    [afterChange, setValue, value]
   );
 
   const addItemComponent = useMemo(() => getAddItemComponent?.(addItem) ?? <></>, [addItem, getAddItemComponent]);

--- a/src/uncontrolled-forms/helpers/useUncontrolledFormHelper.jsx
+++ b/src/uncontrolled-forms/helpers/useUncontrolledFormHelper.jsx
@@ -120,6 +120,10 @@ export function useUncontrolledFormHelper(initialValues, { debounceWait, transfo
       if (formControl) {
         formControl.setValue(value);
       }
+
+      if (validations) {
+        this.validateForm();
+      }
     },
     setFormControl(name, formControl) {
       formHelper.current.setFormControl(name, formControl);

--- a/src/uncontrolled-forms/index.jsx
+++ b/src/uncontrolled-forms/index.jsx
@@ -9,6 +9,7 @@ export * from './UncontrolledFormInputMask';
 export * from './UncontrolledFormRadio';
 export * from './UncontrolledFormSelect';
 export * from './UncontrolledFormSwitch';
+export * from './UncontrolledFormTable';
 export * from './UncontrolledFormTextarea';
 export * from './helpers/useUncontrolledFormControl';
 export * from './helpers/useUncontrolledFormEffect';


### PR DESCRIPTION
## card [criar FormTable/FormList no RBU](https://app.clickup.com/t/86abt19j3)

## Descrição
Este PR tem a inteção de implementar novos campos para os formularios do RBU.
Os novos campos são tabelas de itens. A ideia surgiu no https://github.com/geolaborapp/geolabor/pull/9241/files#diff-9113f84bb39b98160a16c4b5b9a9c2953784bb59b13c312af2303293d864e801, onde foi necesario um campo desses, e tivemos que fazer uma validação usando um throw new Error.

A ideia dos novos campo é criar uma maneira mais facil de implementar campos de "array" em formularios, e que esses campos possam ser validados pelo proprio form do RBU, sem a necessidade de validações no onSubmit

<img width="2525" height="1404" alt="image" src="https://github.com/user-attachments/assets/aeea7f28-a62c-49c6-8427-d25b8baf1c84" />

<img width="2560" height="1394" alt="image" src="https://github.com/user-attachments/assets/07637876-4d39-4868-9225-1e43c88ffecc" />

### sobre o uso do componente
As props mais importantes do componente são a "tableProps", a "getRemoveComponent" e a "getAddItemComponent".
Na "tableProps" é importante definir as columns e o actionLabel. 
No "getRemoveComponent" a ideia é passar uma função que retorne um componente que vai lidar com a exclusão do item da tabela.
No "getAddItemComponent" a ideia é passar uma função que retorne um componente que vai gerar novos itens. Acredito que o mais comum vai ser um modal com outro form.

O spread do tableProps acontece depois das definições das props padrão que usei. Fiz isso para permitir customizar ainda mais o componente.


## Ao revisor
Eu precisei fazer uma correção nas validações do UncontrolledForm. Do jeito que estava antes, as validações aparentemente só aconteciam no momento em que os campo era registrados. Agora elas devem acontecer sempre que o form sofrer alterações.

## Ao tester
teste os novos campo nos dois forms