### PR TITLE
feat: Aumenta o tempo de exibição do toast quando a mensagem de erro for grande

### DIFF
--- a/src/toasts/useToastState.js
+++ b/src/toasts/useToastState.js
@@ -34,12 +34,14 @@ export function useToastState({ unique, messageFormatter, customToasts, onClose 
       const toastId = nextId;
       const _message = isFunction(messageFormatter) ? messageFormatter(message) : message;
 
-      // Automatically increase autoClose to 7000ms if message is longer than 150 characters
       const CHAR_THRESHOLD = 150;
-      const EXTENDED_CLOSE_TIME = 7000;
+      const EXTENDED_CLOSE_TIME = 10000;
       let finalAutoClose = autoClose;
+      let closeControl = !finalAutoClose;
+
       if (isNumber(autoClose) && autoClose === 5000 && _message.length > CHAR_THRESHOLD) {
         finalAutoClose = EXTENDED_CLOSE_TIME;
+        closeControl = true;
       }
 
       push(position, {
@@ -47,7 +49,7 @@ export function useToastState({ unique, messageFormatter, customToasts, onClose 
         message: _message,
         type,
         position,
-        closeControl: !finalAutoClose,
+        closeControl,
       });
 
       if (isNumber(finalAutoClose) && !isNaN(finalAutoClose)) {

--- a/src/toasts/useToastState.js
+++ b/src/toasts/useToastState.js
@@ -39,7 +39,7 @@ export function useToastState({ unique, messageFormatter, customToasts, onClose 
       let finalAutoClose = autoClose;
       let closeControl = !finalAutoClose;
 
-      if (isNumber(autoClose) && autoClose === 5000 && _message.length > CHAR_THRESHOLD) {
+      if (isNumber(autoClose) && autoClose === 5000 && _message?.length > CHAR_THRESHOLD) {
         finalAutoClose = EXTENDED_CLOSE_TIME;
         closeControl = true;
       }

--- a/src/toasts/useToastState.js
+++ b/src/toasts/useToastState.js
@@ -34,18 +34,26 @@ export function useToastState({ unique, messageFormatter, customToasts, onClose 
       const toastId = nextId;
       const _message = isFunction(messageFormatter) ? messageFormatter(message) : message;
 
+      // Automatically increase autoClose to 7000ms if message is longer than 150 characters
+      const CHAR_THRESHOLD = 150;
+      const EXTENDED_CLOSE_TIME = 7000;
+      let finalAutoClose = autoClose;
+      if (isNumber(autoClose) && autoClose === 5000 && _message.length > CHAR_THRESHOLD) {
+        finalAutoClose = EXTENDED_CLOSE_TIME;
+      }
+
       push(position, {
         id: toastId,
         message: _message,
         type,
         position,
-        closeControl: !autoClose,
+        closeControl: !finalAutoClose,
       });
 
-      if (isNumber(autoClose) && !isNaN(autoClose)) {
+      if (isNumber(finalAutoClose) && !isNaN(finalAutoClose)) {
         const timeoutId = setTimeout(() => {
           close(position, toastId);
-        }, autoClose);
+        }, finalAutoClose);
 
         timeoutRefs.current[toastId] = { timeoutId, position };
       }

--- a/src/toasts/useToasts.js
+++ b/src/toasts/useToasts.js
@@ -11,7 +11,7 @@ export function useToasts() {
      * @param {string} message
      * @param {object} options Configurations object
      * @param {string} options.type toast color based on bootstrap theme ('info' - default, 'success', 'danger', 'warning')
-     * @param {number} options.autoClose miliseconds to automatically close toast (default 5000, automatically increased to 7000 if message > 150 characters)
+     * @param {number} options.autoClose miliseconds to automatically close toast (default 5000, automatically increased to 10000 if message > 150 characters)
      * @param {string} options.position toast position ('TOP_LEFT', 'TOP_RIGHT' - default, 'BOTTOM_LEFT', 'BOTTOM_RIGHT')
      *
      * @returns {func} a closeToast function to close the opened toast

--- a/src/toasts/useToasts.js
+++ b/src/toasts/useToasts.js
@@ -11,7 +11,7 @@ export function useToasts() {
      * @param {string} message
      * @param {object} options Configurations object
      * @param {string} options.type toast color based on bootstrap theme ('info' - default, 'success', 'danger', 'warning')
-     * @param {number} options.autoClose miliseconds to automatically close toast (default 5000)
+     * @param {number} options.autoClose miliseconds to automatically close toast (default 5000, automatically increased to 7000 if message > 150 characters)
      * @param {string} options.position toast position ('TOP_LEFT', 'TOP_RIGHT' - default, 'BOTTOM_LEFT', 'BOTTOM_RIGHT')
      *
      * @returns {func} a closeToast function to close the opened toast


### PR DESCRIPTION
Tinhamos um padrão de 5 segundos de exibição de toast, que quando a mensagem de erro for muito longa, acaba não sendo o suficiente. Então adicionei uma tratativa para que, quando a mensagem tiver mais de 150 caracteres, o toast será exibido por 10 segundos, e terá um 'x' para fechar manualmente.