### PR TITLE
fix: corrige warning de input sem onchange no formtable

### DIFF
--- a/src/forms/FormTable.jsx
+++ b/src/forms/FormTable.jsx
@@ -144,6 +144,7 @@ export function FormTable({
         {...attrs}
         ref={registerRef}
         id={name}
+        onChange={() => {}}
         value={value?.length > 0 ? '1' : ''} //for required validation
       />
       {addItemComponent}

--- a/src/uncontrolled-forms/UncontrolledFormTable.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormTable.jsx
@@ -150,6 +150,7 @@ export function UncontrolledFormTable({
         {...attrs}
         ref={registerInputRef}
         id={name}
+        onChange={() => {}}
         value={value?.length > 0 ? '1' : ''} //for required validation
       />
       {addItemComponent}


### PR DESCRIPTION
Este PR tem a intenção de corrigir o warning de input sem onchange, que aparece quando usamos o formtable.
Reparei nesse problema quando trabalhava no https://github.com/geolaborapp/geolabor/pull/10386

<img width="985" height="510" alt="image" src="https://github.com/user-attachments/assets/4a792e8e-5670-41a7-8b5f-c2968373b2e7" />
