### PR TITLE
fix: corrige autocomplete com openOnFocus em mobile

### DIFF
--- a/src/forms/FormAutocomplete.jsx
+++ b/src/forms/FormAutocomplete.jsx
@@ -81,6 +81,7 @@ export function FormAutocomplete({
   const [ignoreBlur, setIgnoreBlur] = useState(false);
   const [isFocused, setFocus] = useState(false);
   const searchInputRef = useRef(null);
+  const openTimerRef = useRef(null);
 
   const registerRef = useCallback(register, [register]);
   const disabled = booleanOrFunction(_disabled, getFormData());
@@ -123,7 +124,7 @@ export function FormAutocomplete({
 
   const onSearchInputFocus = useCallback(() => {
     if (openOnFocus) {
-      setTimeout(() => {
+      openTimerRef.current = setTimeout(() => {
         open();
       }, 100);
     }
@@ -169,6 +170,7 @@ export function FormAutocomplete({
 
   const onSelectItem = useCallback(
     ({ value, label }) => {
+      clearTimeout(openTimerRef.current);
       setValue(value);
       setSearchValue(label);
       setSelectedItem({ value, label });

--- a/src/forms/FormAutocompleteTag.jsx
+++ b/src/forms/FormAutocompleteTag.jsx
@@ -51,6 +51,7 @@ export function FormAutocompleteTag({
   const [isFocused, setFocus] = useState(false);
 
   const searchInputRef = useRef(null);
+  const openTimerRef = useRef(null);
 
   const value = useMemo(() => getValue() || [], [getValue]);
   const options = useMemo(() => {
@@ -168,7 +169,7 @@ export function FormAutocompleteTag({
 
   const onSearchInputFocus = useCallback(() => {
     if (openOnFocus) {
-      setTimeout(() => {
+      openTimerRef.current = setTimeout(() => {
         open();
       }, 100);
     }
@@ -200,6 +201,7 @@ export function FormAutocompleteTag({
 
   const onSelectItem = useCallback(
     ({ value }) => {
+      clearTimeout(openTimerRef.current);
       addTag(value);
       setSearchValue('');
       setIgnoreBlur(false);

--- a/src/uncontrolled-forms/UncontrolledFormAutocomplete.jsx
+++ b/src/uncontrolled-forms/UncontrolledFormAutocomplete.jsx
@@ -80,6 +80,7 @@ export function UncontrolledFormAutocomplete({
   const [ignoreBlur, setIgnoreBlur] = useState(false);
   const [isFocused, setFocus] = useState(false);
   const searchInputRef = useRef(null);
+  const openTimerRef = useRef(null);
 
   const disabled = booleanOrFunction(_disabled, getFormData());
   const required = booleanOrFunction(_required, getFormData());
@@ -122,7 +123,7 @@ export function UncontrolledFormAutocomplete({
 
   const onSearchInputFocus = useCallback(() => {
     if (openOnFocus) {
-      setTimeout(() => {
+      openTimerRef.current = setTimeout(() => {
         open();
       }, 100);
     }
@@ -168,6 +169,7 @@ export function UncontrolledFormAutocomplete({
 
   const onSelectItem = useCallback(
     ({ value, label }) => {
+      clearTimeout(openTimerRef.current);
       setValue(value);
       setSearchValue(label);
       setSelectedItem({ value, label });


### PR DESCRIPTION
### Problema:
Ao usar um FormAutocomplete que usa um openOnFocus em mobile, o dropdown de seleção reabre após selecionar uma opção.

### Causa:
Diferença entre desktop e mobile e o componente foi feito pensando em desktop. 
- Em desktop o mousedown chama onSelectItem diretamente, e o input não recebe nenhum evento de blur. 
- Em mobile o touchStart causa um blur no input, que tem um ignoreBlur=true então o input é refocado, mas quando o input recebe o foco o onSearchInputFocus agente um open() para 100ms depois, e quando chega nesses 100ms já ocorreu o evento de close(), então o dropdown reabre e fica aberto.

### Solução:
Limpar qualquer timer de open pendente ao selecionar uma opção no onSelectItem.

### Teste:
Qualquer autocomplete com openOnFocus, como o Use o "Autocomplete that opens on focus" (autocompleteField2).